### PR TITLE
 회원, 게시글, 댓글, 카테고리 엔티티 작성하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,11 +24,23 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// 1. Spring Web JPA
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// 2. Validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// 3. H2
+	runtimeOnly 'com.h2database:h2'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dedication/force/domain/Article.java
+++ b/src/main/java/com/dedication/force/domain/Article.java
@@ -1,0 +1,38 @@
+package com.dedication.force.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Article {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "article_id", nullable = false, updatable = false)
+    private Long id;
+
+    @Column(length = 50, nullable = false)
+    private String title;
+
+    @Column(length = 3000, nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private ZonedDateTime createdAt;
+
+    @Column(nullable = false)
+    private ZonedDateTime modifiedAt;
+
+    @JoinColumn(name = "member_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ArticleCategory> articleCategories;
+}

--- a/src/main/java/com/dedication/force/domain/ArticleCategory.java
+++ b/src/main/java/com/dedication/force/domain/ArticleCategory.java
@@ -1,0 +1,23 @@
+package com.dedication.force.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ArticleCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "ArticleCategory_id", nullable = false, updatable = false)
+    private Long id;
+
+    @JoinColumn(name = "article_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Article article;
+
+    @JoinColumn(name = "category_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Category category;
+}

--- a/src/main/java/com/dedication/force/domain/Category.java
+++ b/src/main/java/com/dedication/force/domain/Category.java
@@ -1,0 +1,23 @@
+package com.dedication.force.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.Set;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id", nullable = false, updatable = false)
+    private Long id;
+
+    @Column(length = 12, nullable = false)
+    private String name;
+
+    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ArticleCategory> articleCategories;
+}

--- a/src/main/java/com/dedication/force/domain/Comment.java
+++ b/src/main/java/com/dedication/force/domain/Comment.java
@@ -1,0 +1,30 @@
+package com.dedication.force.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.time.ZonedDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Comment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id", nullable = false, updatable = false)
+    private Long id;
+
+    @Column(length = 200, nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private ZonedDateTime createdAt;
+
+    @Column(nullable = false)
+    private ZonedDateTime modifiedAt;
+
+    @JoinColumn(name = "member_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+}

--- a/src/main/java/com/dedication/force/domain/Member.java
+++ b/src/main/java/com/dedication/force/domain/Member.java
@@ -1,0 +1,32 @@
+package com.dedication.force.domain;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id", nullable = false, updatable = false)
+    private Long id;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String phone;
+
+    @OneToMany(mappedBy = "member", cascade = {CascadeType.ALL})
+    private List<Article> articles;
+
+    @OneToMany(mappedBy = "member", cascade = {CascadeType.ALL})
+    private List<Comment> comments;
+}


### PR DESCRIPTION
- 회원 엔티티 생성하기
-  게시글 엔티티 생성하기
-  댓글 엔티티 생성하기
- 카테고리 엔티티 생성하기
- 게시글카테고리 엔티티 생성하기

엔티티 생성에 필요한 의존성을 추가한다.

엔티티 생성 미 연관관계 매핑했다.

- 한 개의 게시글은 여러 개의 카테고리에 포함될 수 있다.
- 한 개의 카테고리는 여러 개의 게시글에 포함될 수 있다.

다대다 연관관계를 갖는 게시글과 카테고리를 풀어내기 위해 게시글카테고리 엔티티를 추가하고, orphanRemoval = true 으로 설정해서 카테고리가 삭제되거나 게시글이 삭제될 때 게시글카테고리 테이블에 불필요하게 남는 필드를 함께 삭제한다.

게시글과 카테고리 양 쪽에  orphanRemoval = true 로 설정되어 있기 때문에 상당히 주의가 필요하다고 보인다. 서비스 로직에서 처리할 수 있을 것으로 보인다. 혹은 한 쪽에서  orphanRemoval = true 을 제거해도 괜찮은 방법으로도 보인다.

this closes #2 