### PR TITLE
공통 예외 처리 구현하기

### DIFF
--- a/src/main/java/com/dedication/force/common/CustomExceptionHandler.java
+++ b/src/main/java/com/dedication/force/common/CustomExceptionHandler.java
@@ -1,0 +1,48 @@
+package com.dedication.force.common;
+
+import com.dedication.force.common.exception.CustomAPIException;
+import com.dedication.force.common.exception.CustomDataNotFoundException;
+import com.dedication.force.common.exception.CustomForbiddenException;
+import com.dedication.force.common.exception.CustomValidationException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import static org.springframework.http.HttpStatus.*;
+
+@RestControllerAdvice
+public class CustomExceptionHandler {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+
+    @ExceptionHandler(CustomAPIException.class)
+    @ResponseStatus(BAD_REQUEST)
+    public ResponseEntity<HttpResponse<Void>> apiException(CustomAPIException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), BAD_REQUEST);
+    }
+
+    @ExceptionHandler(CustomDataNotFoundException.class)
+    @ResponseStatus(NOT_FOUND)
+    public ResponseEntity<HttpResponse<Void>> dataNotFoundException(CustomDataNotFoundException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), NOT_FOUND);
+    }
+
+    @ExceptionHandler(CustomForbiddenException.class)
+    @ResponseStatus(FORBIDDEN)
+    public ResponseEntity<HttpResponse<Void>> forbiddenException(CustomForbiddenException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), FORBIDDEN);
+    }
+
+    @ExceptionHandler(CustomValidationException.class)
+    @ResponseStatus(BAD_REQUEST)
+    public ResponseEntity<?> validationApiException(CustomValidationException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), e.getErrorMap()), BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/dedication/force/common/HttpResponse.java
+++ b/src/main/java/com/dedication/force/common/HttpResponse.java
@@ -1,0 +1,3 @@
+package com.dedication.force.common;
+
+public record HttpResponse<T>(Integer code, String message, T data) { }

--- a/src/main/java/com/dedication/force/common/aop/CustomValidationAdvice.java
+++ b/src/main/java/com/dedication/force/common/aop/CustomValidationAdvice.java
@@ -1,0 +1,41 @@
+package com.dedication.force.common.aop;
+
+import com.dedication.force.common.exception.CustomValidationException;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+@Aspect
+public class CustomValidationAdvice {
+
+    // POST, PUT, PATCH: body
+    @Pointcut("@annotation(org.springframework.web.bind.annotation.PostMapping) || " +
+            "@annotation(org.springframework.web.bind.annotation.PutMapping) || " +
+            "@annotation(org.springframework.web.bind.annotation.PatchMapping)")
+    public void requestMapping() {}
+
+    @Around("requestMapping()")
+    public Object validationAdvice(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        Object[] args = proceedingJoinPoint.getArgs();
+        for (Object arg : args) {
+            if (arg instanceof BindingResult bindingResult) {
+                if (bindingResult.hasErrors()) {
+                    Map<String, String> errorMap = new HashMap<>();
+                    for (FieldError error : bindingResult.getFieldErrors()) {
+                        errorMap.put(error.getField(), error.getDefaultMessage());
+                    }
+                    throw new CustomValidationException("유효성 검사 실패", errorMap);
+                }
+            }
+        }
+        return proceedingJoinPoint.proceed();
+    }
+}

--- a/src/main/java/com/dedication/force/common/exception/CustomAPIException.java
+++ b/src/main/java/com/dedication/force/common/exception/CustomAPIException.java
@@ -1,0 +1,8 @@
+package com.dedication.force.common.exception;
+
+public class CustomAPIException extends RuntimeException {
+
+    public CustomAPIException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/dedication/force/common/exception/CustomDataNotFoundException.java
+++ b/src/main/java/com/dedication/force/common/exception/CustomDataNotFoundException.java
@@ -1,0 +1,7 @@
+package com.dedication.force.common.exception;
+
+public class CustomDataNotFoundException extends RuntimeException {
+    public CustomDataNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/dedication/force/common/exception/CustomForbiddenException.java
+++ b/src/main/java/com/dedication/force/common/exception/CustomForbiddenException.java
@@ -1,0 +1,7 @@
+package com.dedication.force.common.exception;
+
+public class CustomForbiddenException extends RuntimeException {
+    public CustomForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/dedication/force/common/exception/CustomValidationException.java
+++ b/src/main/java/com/dedication/force/common/exception/CustomValidationException.java
@@ -1,0 +1,16 @@
+package com.dedication.force.common.exception;
+
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class CustomValidationException extends RuntimeException {
+
+    private final Map<String, String> errorMap;
+
+    public CustomValidationException(String message, Map<String, String> errorMap) {
+        super(message);
+        this.errorMap = errorMap;
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/force
+    username: sa
+    password: sa
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        #        show_sql: true
+        format_sql: true
+
+logging.level:
+  org.hibernate.SQL: debug
+#  org.hibernate.type: trace

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,18 @@
+spring:
+  datasource:
+    url: jdbc:h2:tcp://localhost/~/force
+    username: sa
+    password: sa
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        #        show_sql: true
+        format_sql: true
+
+logging.level:
+  org.hibernate.SQL: debug
+#  org.hibernate.type: trace

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=force


### PR DESCRIPTION
공통 예외 처리해야 되는 예외를 생각하자.

 POST, PUT, PATCH 응답 http body 데이터가 있는 예외 구현하기 -> BindingResult 가 파라미터로 있으면 동작하도록 구현하자.
- Custom 예외 구현하기
-  Forbidden, DataNotFound, API, Validation Exception 구현하고, Exception Handler 구현하기
- 공통 응답 클래스 구현하기
-  HttpResponse 클래스 구현하기

각 실행 환경마다 application.yml 설정을 다르게 하기 위해서 파일을 구분한다. 추후에 application-xxx.yml 파일을 gitignore 로 빼는 방법도 생각해보자.

응답 HTTP Body 는 항상 동일한 형식으로 전달하기 위해 생성한 응답 클래스이다. 아래와 같이 Body 를 클라이언트에게 응답한다.
```
MockHttpServletResponse:
           Status = 400
    Error message = null
          Headers = [Content-Type:"application/json"]
     Content type = application/json
             Body = {"code":-1,"message":"유효성 검사 실패","data":{"password":"비밀번호: 필수 정보입니다.","phone":"휴대전화번호: 필수 정보입니다.","email":"이메일: 필수 정보입니다."}}
    Forwarded URL = null
   Redirected URL = null
          Cookies = []
```

POST, PUT, PATCH 요청을 처리하는 메서드들에 대해 유효성 검사를 수행한다. 모두 HTTP Body 안에 데이터가 존재하는 hTTP 메서드이다.

컨트롤러에서 메서드의 매개변수로 BindingReulst 가 존재하면 유효성 검사를 수행하고, 모든 에러를 Map 으로 저장하고, HttpResponse 응답 클래스의 Data 필드에 포함하여 클라이언트에게 발생된 모든 예외 및 에러를 응답한다.

문제가 없으면 정상적인 동작을 이어서 진행한다.

1. 데이터를 찾을 수 없는 경우: NotFound
2. 금지된 경우: Forbidden
3. 대부분의 문제가 발생한 경우: Bad Request

참고로, 마지막 ValidationException 또한 Bad Request 이다. 그러나 컨트롤러에서 BindingResult 타입의 매개변수가 존재해야만 동작되는 유효성 검사를 위한 예외 처리 클래스이다.

따라서 컨트롤러 이외에서 Bad Request 예외를 처리하기 위한 클래스는 APIException 을 사용하면 된다.

This closes #3 