### PR TITLE
회원, 게시글, 댓글 ,카테고리 컨트롤러, 서비스, 리포지토리 생성하기

### DIFF
--- a/src/main/java/com/dedication/force/controller/AuthController.java
+++ b/src/main/java/com/dedication/force/controller/AuthController.java
@@ -1,0 +1,42 @@
+package com.dedication.force.controller;
+
+import com.dedication.force.common.HttpResponse;
+import com.dedication.force.domain.dto.AddMemberRequest;
+import com.dedication.force.service.MemberService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/auth")
+@RestController
+public class AuthController {
+
+    private final MemberService memberService;
+
+    // 회원 등록
+    @PostMapping("")
+    public ResponseEntity<HttpResponse<Void>> addMember(@RequestBody @Valid AddMemberRequest request, BindingResult result) {
+        memberService.addMember(request);
+        return new ResponseEntity<>(new HttpResponse<>(1, "회원가입에 성공했습니다.", null), HttpStatus.CREATED);
+    }
+
+    // 모든 회원 조회
+
+    // 단건 회원 조회(id)
+
+    // 아이디 중복 확인
+
+    // 전화번호 중복 확인
+
+    // 회원 수정
+
+    // 회원 삭제
+}

--- a/src/main/java/com/dedication/force/domain/dto/AddMemberRequest.java
+++ b/src/main/java/com/dedication/force/domain/dto/AddMemberRequest.java
@@ -1,0 +1,38 @@
+package com.dedication.force.domain.dto;
+
+import com.dedication.force.domain.entity.Member;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record AddMemberRequest(
+        @NotBlank(message = "이메일: 필수 정보입니다.")
+        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$", message = "이메일: 유효한 이메일 주소를 입력해주세요.")
+        @Size(min = 6, max = 32, message = "이메일: 유효한 이메일 주소를 입력해주세요.")
+        String email,
+
+        @NotBlank(message = "비밀번호: 필수 정보입니다.")
+        @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}"
+                , message = "비밀번호: 8~20자 영문 대소문자, 숫자, 특수문자를 조합하여 작성해야 합니다.")
+        @Size(min = 8, max = 20, message = "비밀번호: 8~20자 영문 대소문자, 숫자, 특수문자를 조합하여 작성해야 합니다.")
+        String password,
+
+        @NotBlank(message = "휴대전화번호: 필수 정보입니다.")
+        @Pattern(regexp = "^[0-9]{10,11}$", message = "휴대전화번호: 10~11자 숫자만 입력해주세요.")
+        @Size(min = 10, max = 11, message = "휴대전화번호: 10~11자 숫자만 입력해주세요.")
+        String phone
+) {
+    public static AddMemberRequest from(Member member) {
+        return new AddMemberRequest(
+                member.getEmail(),
+                member.getPassword(),
+                member.getPhone());
+    }
+
+    public Member toEntity() {
+        return Member.of(
+                this.email,
+                this.password,
+                this.phone);
+    }
+}

--- a/src/main/java/com/dedication/force/domain/entity/Article.java
+++ b/src/main/java/com/dedication/force/domain/entity/Article.java
@@ -1,21 +1,25 @@
-package com.dedication.force.domain;
+package com.dedication.force.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import java.time.ZonedDateTime;
+import java.util.Set;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Comment {
+public class Article {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "comment_id", nullable = false, updatable = false)
+    @Column(name = "article_id", nullable = false, updatable = false)
     private Long id;
 
-    @Column(length = 200, nullable = false)
+    @Column(length = 50, nullable = false)
+    private String title;
+
+    @Column(length = 3000, nullable = false)
     private String content;
 
     @Column(nullable = false)
@@ -27,4 +31,7 @@ public class Comment {
     @JoinColumn(name = "member_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ArticleCategory> articleCategories;
 }

--- a/src/main/java/com/dedication/force/domain/entity/ArticleCategory.java
+++ b/src/main/java/com/dedication/force/domain/entity/ArticleCategory.java
@@ -1,4 +1,4 @@
-package com.dedication.force.domain;
+package com.dedication.force.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/dedication/force/domain/entity/Category.java
+++ b/src/main/java/com/dedication/force/domain/entity/Category.java
@@ -1,4 +1,4 @@
-package com.dedication.force.domain;
+package com.dedication.force.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/dedication/force/domain/entity/Comment.java
+++ b/src/main/java/com/dedication/force/domain/entity/Comment.java
@@ -1,26 +1,21 @@
-package com.dedication.force.domain;
+package com.dedication.force.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import java.time.ZonedDateTime;
-import java.util.HashSet;
-import java.util.Set;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Article {
+public class Comment {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "article_id", nullable = false, updatable = false)
+    @Column(name = "comment_id", nullable = false, updatable = false)
     private Long id;
 
-    @Column(length = 50, nullable = false)
-    private String title;
-
-    @Column(length = 3000, nullable = false)
+    @Column(length = 200, nullable = false)
     private String content;
 
     @Column(nullable = false)
@@ -32,7 +27,4 @@ public class Article {
     @JoinColumn(name = "member_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
-
-    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Set<ArticleCategory> articleCategories;
 }

--- a/src/main/java/com/dedication/force/domain/entity/Member.java
+++ b/src/main/java/com/dedication/force/domain/entity/Member.java
@@ -1,11 +1,13 @@
-package com.dedication.force.domain;
+package com.dedication.force.domain.entity;
 
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.List;
 
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Member {
@@ -24,9 +26,27 @@ public class Member {
     @Column(nullable = false)
     private String phone;
 
+    private ZonedDateTime createdAt;
+
+    private ZonedDateTime modifiedAt;
+
     @OneToMany(mappedBy = "member", cascade = {CascadeType.ALL})
     private List<Article> articles;
 
     @OneToMany(mappedBy = "member", cascade = {CascadeType.ALL})
     private List<Comment> comments;
+
+    private Member(String email, String password, String phone) {
+        this.email = email;
+        this.password = password;
+        this.phone = phone;
+
+        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        this.createdAt = now;
+        this.modifiedAt = now;
+    }
+
+    public static Member of(String email, String password, String phone) {
+        return new Member(email, password, phone);
+    }
 }

--- a/src/main/java/com/dedication/force/repository/ArticleRepository.java
+++ b/src/main/java/com/dedication/force/repository/ArticleRepository.java
@@ -1,0 +1,7 @@
+package com.dedication.force.repository;
+
+import com.dedication.force.domain.entity.Article;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+}

--- a/src/main/java/com/dedication/force/repository/CategoryRepository.java
+++ b/src/main/java/com/dedication/force/repository/CategoryRepository.java
@@ -1,0 +1,7 @@
+package com.dedication.force.repository;
+
+import com.dedication.force.domain.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/dedication/force/repository/CommentRepository.java
+++ b/src/main/java/com/dedication/force/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.dedication.force.repository;
+
+import com.dedication.force.domain.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/dedication/force/repository/MemberRepository.java
+++ b/src/main/java/com/dedication/force/repository/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.dedication.force.repository;
+
+import com.dedication.force.domain.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Boolean existsByEmail(String email);
+    Boolean existsByPhone(String phone);
+}

--- a/src/main/java/com/dedication/force/service/ArticleService.java
+++ b/src/main/java/com/dedication/force/service/ArticleService.java
@@ -1,0 +1,18 @@
+package com.dedication.force.service;
+
+import com.dedication.force.repository.ArticleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ArticleService {
+
+    private final ArticleRepository articleRepository;
+
+    // 1. 게시글 등록
+
+    // 2. 게시글 수정
+
+    // 3. 게시글 삭제
+}

--- a/src/main/java/com/dedication/force/service/CategoryService.java
+++ b/src/main/java/com/dedication/force/service/CategoryService.java
@@ -1,0 +1,18 @@
+package com.dedication.force.service;
+
+import com.dedication.force.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    // 1. 카테고리 등록
+
+    // 2. 카테고리 수정
+
+    // 3. 카테고리 삭제
+}

--- a/src/main/java/com/dedication/force/service/CommentService.java
+++ b/src/main/java/com/dedication/force/service/CommentService.java
@@ -1,0 +1,18 @@
+package com.dedication.force.service;
+
+import com.dedication.force.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CommentService {
+
+    private final CommentRepository commentRepository;
+
+    // 1. 댓글 생성
+
+    // 2. 댓글 수정
+
+    // 3. 댓글 삭제
+}

--- a/src/main/java/com/dedication/force/service/MemberService.java
+++ b/src/main/java/com/dedication/force/service/MemberService.java
@@ -1,0 +1,54 @@
+package com.dedication.force.service;
+
+import com.dedication.force.common.exception.CustomAPIException;
+import com.dedication.force.domain.dto.AddMemberRequest;
+import com.dedication.force.repository.MemberRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@RequiredArgsConstructor
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    private static final String EMAIL_PATTERN = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$";
+    private static final String PHONE_PATTERN = "^[0-9]{10,11}$";
+
+    // 이메일 중복 확인하기
+    public void checkMemberEmail(String email) {
+        Matcher emailRex = Pattern.compile(EMAIL_PATTERN).matcher(email);
+
+        if (email.isEmpty()) {throw new CustomAPIException("이메일은 필수 입력입니다.");}
+        if (!emailRex.matches()) {throw new CustomAPIException("잘못된 이메일 입니다.");}
+        if (memberRepository.existsByEmail(email)) {throw new CustomAPIException("이미 가입된 이메일 입니다.");}
+    }
+
+    // 전화번호 중복 확인한기
+    public void checkMemberPhone(String phone) {
+        Matcher phoneRex = Pattern.compile(PHONE_PATTERN).matcher(phone);
+
+        if (phone.isEmpty()) {throw new CustomAPIException("휴대전화번호는 필수 입력입니다.");}
+        if (!phoneRex.matches()) {throw new CustomAPIException("잘못된 휴대전화번호 입니다.");}
+        if (memberRepository.existsByPhone(phone)) {throw new CustomAPIException("이미 가입된 휴대전화번호 입니다.");}
+    }
+
+    // 회원 등록
+    @Transactional
+    public void addMember(AddMemberRequest request) {
+        checkMemberPhone(request.phone());
+        checkMemberEmail(request.email());
+
+        memberRepository.save(request.toEntity());
+    }
+
+
+    // 회원 수정
+
+    // 회원 삭제
+
+}


### PR DESCRIPTION
회원, 게시글, 댓글, 카테고리 엔티티의 컨트롤러, 서비스, 리포지토리를 생성한다.
임시로 회원 등록 엔드포인트를 생성하고 테스트 케이스를 작성하여 유효성 검사 확인 및 정상적인 실행이 되는지 확인한다.

- 컨트롤러, 서비스, 리포지토리 생성하기
-  회원 등록 엔드포인트 생성하기
-  회원 등록 유효성 검사 테스트 케이스 작성하기

회원 등록을 위해 회원 서비스 안에는 회원 등록 코드가 작성되어 있고, 나머지는 클래스만 생성하고 선언한 상태.

domain 디렉터리 안에 dto, denttiy 디렉터리로 구분하기 위해 엔티티 클래스들을 옮겼다. 생각보다 디렉터리 혹은 클래스가 많이 생성될 것으로 예상되기 때문에 생각날 때 옮겼다.

DTO 를 어떻게 작성하면 좋을까 고민은 정말 많이 하면서 찾아봤다. 지금 방식이 직관적이고 가장 적절한 것 같다고 생각하여 DTO 를 작성했는데, 추후에 더 좋은 방법이 있다면 변경이 될 여지가 있다.

유효성 검사를 위해 NotBlank, Pattern, Size 어노테이션을 적용했고, 모두 BindingResult 타입 매개변수가 있는 컨트롤러의 메서드의 요청에 동작한다. 또한 CustomException 도 Map 에 포함하여 모든 예외 발생 혹은 에러 확인이 가능하다.

그 이외 나머지 커스텀 예외는 RuntimeException 클래스를 상속받고 super() 로 메시지를 전달하는 것으로 작성했다.

테스트 코드는
1. 정상적인 회원 등록
2. 유효성 실패
3. 빈 값(null)

세 가지에 대해 테스트 케이스를 작성했다.

This closes #4 
