### PR TITLE
스프링 시큐리티 적용하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 	// 3. H2
 	runtimeOnly 'com.h2database:h2'
 
+	// 4. Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	testImplementation 'org.springframework.security:spring-security-test'
 
 }
 

--- a/src/main/java/com/dedication/force/common/config/SecurityConfig.java
+++ b/src/main/java/com/dedication/force/common/config/SecurityConfig.java
@@ -1,0 +1,64 @@
+package com.dedication.force.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .csrf(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                .httpBasic(AbstractHttpConfigurer::disable);
+
+        http
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
+                        .requestMatchers("/api/v1/**").permitAll()); // TODO: 임시로 모든 요청을 허용
+
+        return http.build();
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration corsConfiguration = new CorsConfiguration();
+
+        corsConfiguration.setAllowedOriginPatterns(List.of("*")); // 모든 허용(React + Next.js + .etc)
+        corsConfiguration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"));
+        corsConfiguration.setAllowedHeaders(List.of("Authorization", "Cache-Control", "Content-Type"));
+        corsConfiguration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", corsConfiguration);
+
+        return source;
+    }
+
+}

--- a/src/main/java/com/dedication/force/common/config/WebConfig.java
+++ b/src/main/java/com/dedication/force/common/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.dedication.force.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedOrigins("http://localhost:8080")
+                .allowedMethods("GET", "POST", "PATCH", "PUT", "OPTIONS", "DELETE");
+    }
+}

--- a/src/main/java/com/dedication/force/domain/dto/AddMemberRequest.java
+++ b/src/main/java/com/dedication/force/domain/dto/AddMemberRequest.java
@@ -1,6 +1,5 @@
 package com.dedication.force.domain.dto;
 
-import com.dedication.force.domain.entity.Member;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
@@ -21,18 +20,4 @@ public record AddMemberRequest(
         @Pattern(regexp = "^[0-9]{10,11}$", message = "휴대전화번호: 10~11자 숫자만 입력해주세요.")
         @Size(min = 10, max = 11, message = "휴대전화번호: 10~11자 숫자만 입력해주세요.")
         String phone
-) {
-    public static AddMemberRequest from(Member member) {
-        return new AddMemberRequest(
-                member.getEmail(),
-                member.getPassword(),
-                member.getPhone());
-    }
-
-    public Member toEntity() {
-        return Member.of(
-                this.email,
-                this.password,
-                this.phone);
-    }
-}
+) { }

--- a/src/main/java/com/dedication/force/service/MemberService.java
+++ b/src/main/java/com/dedication/force/service/MemberService.java
@@ -2,9 +2,11 @@ package com.dedication.force.service;
 
 import com.dedication.force.common.exception.CustomAPIException;
 import com.dedication.force.domain.dto.AddMemberRequest;
+import com.dedication.force.domain.entity.Member;
 import com.dedication.force.repository.MemberRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.regex.Matcher;
@@ -15,6 +17,9 @@ import java.util.regex.Pattern;
 public class MemberService {
 
     private final MemberRepository memberRepository;
+
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
 
     private static final String EMAIL_PATTERN = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$";
     private static final String PHONE_PATTERN = "^[0-9]{10,11}$";
@@ -43,7 +48,15 @@ public class MemberService {
         checkMemberPhone(request.phone());
         checkMemberEmail(request.email());
 
-        memberRepository.save(request.toEntity());
+        String encodedPassword = bCryptPasswordEncoder.encode(request.password());
+
+        Member member = Member.of(
+                request.email(),
+                encodedPassword,
+                request.phone()
+        );
+
+        memberRepository.save(member);
     }
 
 

--- a/src/test/java/com/dedication/force/controller/AuthControllerTest.java
+++ b/src/test/java/com/dedication/force/controller/AuthControllerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -41,20 +42,17 @@ class AuthControllerTest {
 
     @DisplayName("[Member][POST]: 회원가입 성공")
     @Test
-    public void GivenValidMember_WhenSignUp_ThenSuccess() throws Exception {
+    public void GivenValidMember_WhenSignUp_ExpectedSuccess() throws Exception {
         // given
-        AddMemberRequest request = new AddMemberRequest(
+        Member member = Member.of(
                 "spring@naver.com",
-                "SpringBoot3.x",
+                "SpringBoot3!",
                 "01012341234"
         );
 
-        // when
-        Member savedMember = request.toEntity();
-
-        // then
+        // Expected
         mockMvc.perform(post("/api/v1/auth")
-                .content(objectMapper.writeValueAsString(savedMember))
+                .content(objectMapper.writeValueAsString(member))
                 .contentType(APPLICATION_JSON))
                 .andExpect(status().isCreated())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(1))
@@ -65,20 +63,18 @@ class AuthControllerTest {
 
     @DisplayName("[Member][POST]: 회원가입 실패- 유효성")
     @Test
-    public void GivenInValidEmailMember_WhenSignUp_ThenFail() throws Exception {
+    public void GivenInValidEmailMember_WhenSignUp_ExpectedFail() throws Exception {
         // given
-        AddMemberRequest request = new AddMemberRequest(
+        Member member = Member.of(
                 "spring",
-                "SpringBoot3",
+                "SpringBoot",
                 "12341234"
         );
 
-        // when
-        Member savedMember = request.toEntity();
 
-        // then
+        // Expected
         mockMvc.perform(post("/api/v1/auth")
-                        .content(objectMapper.writeValueAsString(savedMember))
+                        .content(objectMapper.writeValueAsString(member))
                         .contentType(APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(-1))
@@ -93,18 +89,15 @@ class AuthControllerTest {
     @Test
     public void GivenEmptyMember_WhenSignUp_ThenFail() throws Exception {
         // given
-        AddMemberRequest request = new AddMemberRequest(
+        Member member = Member.of(
                 null,
                 null,
                 null
         );
 
-        // when
-        Member savedMember = request.toEntity();
-
-        // then
+        // Expected
         mockMvc.perform(post("/api/v1/auth")
-                        .content(objectMapper.writeValueAsString(savedMember))
+                        .content(objectMapper.writeValueAsString(member))
                         .contentType(APPLICATION_JSON))
                 .andExpect(status().isBadRequest())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.code").value(-1))


### PR DESCRIPTION
회원 등록 엔드포인트를 생성했다. 이제는 회원 가입되는 시점에 스프링 시큐리티 적용이 필요하다!
JWT 토큰 인증 방식으로 개발을 진행할 목표이기 때문에 세션은 사용하지 않으므로 비활성화하자.

 - 스프링 시큐리티 세팅하기
 - 비밀번호 암호화하기
 - 회원 등록 암호화 설정하기


회원 등록 엔드포인트 생성에 따라서 spring security 의존성을 추가했다.

Bearer + JWT 토큰 인증 방식을 채택과 시큐리티 따라서 다음과 같이 설정했다.

1. cors 설정하기
  CORS 활성화하여 특정 도메인에서 요청 허용 및 제한한다.

2. session 비활성화
  JWT 토큰 사용한다.

3. csrf 비활성화
  REST API 방식이기 때문에 비활성화 한다.

4. formLogin 비활성화
  react.js 혹은 vue.js 프론트 있다는 가정으로 진행한다.

5. headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
X-Frame-Options 헤더를 SAMEORIGIN으로 설정한다. 이는 동일 출처의 페이지에서만 이 페이지를 iframe으로 로드할 수 있도록 한다. 클릭재킹 공격을 방지하기 위해 설정한다.

6. http basic 인증 비활성화
  JWT 토큰 인증 방식 사용한다.

WebConfig 를 Authorization 헤더 사용에 따라 설정한다. 쿠키 사용 안하기 때문에 allowCredentials(true) 는 없다.

회원의 비밀번호를 암호화 하기 위해서 일부 로직을 변경했다.

테스트 케이스 모두 성공적으로 통과하는 것을 확인했다.