### PR TITLE
Querydsl 적용 및 모든 회원 조회하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,8 +44,18 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	testImplementation 'org.springframework.security:spring-security-test'
 
+	// 5. QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+clean {
+	delete file('src/main/generated')
 }

--- a/src/main/java/com/dedication/force/common/config/QuerydslConfig.java
+++ b/src/main/java/com/dedication/force/common/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.dedication.force.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/dedication/force/common/exception/CustomAPIException.java
+++ b/src/main/java/com/dedication/force/common/exception/CustomAPIException.java
@@ -1,7 +1,6 @@
 package com.dedication.force.common.exception;
 
 public class CustomAPIException extends RuntimeException {
-
     public CustomAPIException(String message) {
         super(message);
     }

--- a/src/main/java/com/dedication/force/controller/AuthController.java
+++ b/src/main/java/com/dedication/force/controller/AuthController.java
@@ -2,16 +2,16 @@ package com.dedication.force.controller;
 
 import com.dedication.force.common.HttpResponse;
 import com.dedication.force.domain.dto.AddMemberRequest;
+import com.dedication.force.domain.entity.Member;
 import com.dedication.force.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @RequiredArgsConstructor
@@ -29,6 +29,10 @@ public class AuthController {
     }
 
     // 모든 회원 조회
+    @GetMapping("")
+    public ResponseEntity<HttpResponse<List<Member>>> allMember() {
+        return new ResponseEntity<>(new HttpResponse<>(1, "모든 회원 조회입니다.", memberService.allMember()), HttpStatus.OK);
+    }
 
     // 단건 회원 조회(id)
 

--- a/src/main/java/com/dedication/force/service/MemberService.java
+++ b/src/main/java/com/dedication/force/service/MemberService.java
@@ -3,14 +3,19 @@ package com.dedication.force.service;
 import com.dedication.force.common.exception.CustomAPIException;
 import com.dedication.force.domain.dto.AddMemberRequest;
 import com.dedication.force.domain.entity.Member;
+import com.dedication.force.domain.entity.QMember;
 import com.dedication.force.repository.MemberRepository;
+import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static com.dedication.force.domain.entity.QMember.member;
 
 @RequiredArgsConstructor
 @Service
@@ -19,6 +24,7 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final JPAQueryFactory queryFactory;
 
 
     private static final String EMAIL_PATTERN = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$";
@@ -33,7 +39,7 @@ public class MemberService {
         if (memberRepository.existsByEmail(email)) {throw new CustomAPIException("이미 가입된 이메일 입니다.");}
     }
 
-    // 전화번호 중복 확인한기
+    // 전화번호 중복 확인하기
     public void checkMemberPhone(String phone) {
         Matcher phoneRex = Pattern.compile(PHONE_PATTERN).matcher(phone);
 
@@ -57,6 +63,16 @@ public class MemberService {
         );
 
         memberRepository.save(member);
+    }
+
+    // 모든 회원 조회
+    @Transactional
+    public List<Member> allMember() {
+        QMember qMember = QMember.member; //기본 인스턴스 사용
+
+        return queryFactory.selectFrom(qMember)
+                .orderBy(qMember.createdAt.asc())
+                .fetch();
     }
 
 

--- a/src/test/java/com/dedication/force/controller/AuthControllerTest.java
+++ b/src/test/java/com/dedication/force/controller/AuthControllerTest.java
@@ -1,8 +1,8 @@
 package com.dedication.force.controller;
 
-import com.dedication.force.domain.dto.AddMemberRequest;
 import com.dedication.force.domain.entity.Member;
 import com.dedication.force.repository.MemberRepository;
+import com.dedication.force.service.MemberService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -10,12 +10,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
+import static org.springframework.http.MediaType.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -34,6 +36,9 @@ class AuthControllerTest {
 
     @Autowired
     private MemberRepository memberRepository;
+
+    @Autowired
+    private MemberService memberService;
 
     @BeforeEach
     public void clean() {
@@ -105,6 +110,37 @@ class AuthControllerTest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.password").value("비밀번호: 필수 정보입니다."))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.phone").value("휴대전화번호: 필수 정보입니다."))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.data.email").value("이메일: 필수 정보입니다."))
+                .andDo(print());
+    }
+
+    @DisplayName("[Member][GET]: 모든 회원 조회")
+    @Test
+    public void GivenMembers_WhenSavedMembers_ThenSuccess() throws Exception {
+        // given
+        Member member1 = Member.of(
+                "spring@naver.com",
+                "SpringBoot3!",
+                "01012341234"
+        );
+        Member member2 = Member.of(
+                "python@naver.com",
+                "python3.12.1",
+                "01045674567"
+        );
+
+        // when
+        memberRepository.save(member1);
+        memberRepository.save(member2);
+
+         // then
+        mockMvc.perform(get("/api/v1/auth")
+                        .contentType(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data.size()").value(2))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].email").value("spring@naver.com"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[0].phone").value("01012341234"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].email").value("python@naver.com"))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.data[1].phone").value("01045674567"))
                 .andDo(print());
     }
 }


### PR DESCRIPTION
지금까지 JPQL 혹은 Spring Data JPA 로 CRUD 를 주로 사용했기 때문에, 이번에는 Querydsl 을 적극적으로 사용할 예정이다.

조회: Querydsl
등록/수정/삭제: JPQL, Spring Data JPA

이렇게 개발을 해보자.

 JPQL 과 Spring Data JPA, Querydsl 의 사용을 구분한 이유를 티스토리에 정리했다.
- https://limdae94.tistory.com/78

This closes #11 