### PR TITLE
회원 권한 엔티티 추가 및 로그인 서비스 구현하기

### DIFF
--- a/src/main/java/com/dedication/force/domain/entity/Member.java
+++ b/src/main/java/com/dedication/force/domain/entity/Member.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -17,7 +18,7 @@ public class Member {
     @Column(name = "member_id", nullable = false, updatable = false)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String email;
 
     @Column(nullable = false)
@@ -31,10 +32,13 @@ public class Member {
     private ZonedDateTime modifiedAt;
 
     @OneToMany(mappedBy = "member", cascade = {CascadeType.ALL})
-    private List<Article> articles;
+    private final List<Article> articles = new ArrayList<>();
 
     @OneToMany(mappedBy = "member", cascade = {CascadeType.ALL})
-    private List<Comment> comments;
+    private final List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = {CascadeType.ALL})
+    private final List<MemberRole> memberRoles = new ArrayList<>();
 
     private Member(String email, String password, String phone) {
         this.email = email;

--- a/src/main/java/com/dedication/force/domain/entity/MemberRole.java
+++ b/src/main/java/com/dedication/force/domain/entity/MemberRole.java
@@ -1,0 +1,35 @@
+package com.dedication.force.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Getter
+@Entity
+public class MemberRole {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @JoinColumn(name = "member_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    public Member member;
+
+    @JoinColumn(name = "role_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    public Role role;
+
+    public void setMember(Member member) {
+        this.member = member;
+        if (!member.getMemberRoles().contains(this)) {
+            member.getMemberRoles().add(this);
+        }
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
+        if (!role.getMemberRoles().contains(this)) {
+            role.getMemberRoles().add(this);
+        }
+    }
+}

--- a/src/main/java/com/dedication/force/domain/entity/Role.java
+++ b/src/main/java/com/dedication/force/domain/entity/Role.java
@@ -1,0 +1,25 @@
+package com.dedication.force.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Role {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "role_id", nullable = false, updatable = false)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private RoleType roleType;
+
+    @OneToMany(mappedBy = "role", fetch = FetchType.LAZY)
+    private List<MemberRole> memberRoles;
+}

--- a/src/main/java/com/dedication/force/domain/entity/RoleType.java
+++ b/src/main/java/com/dedication/force/domain/entity/RoleType.java
@@ -1,0 +1,7 @@
+package com.dedication.force.domain.entity;
+
+public enum RoleType {
+    USER,
+    MANAGER,
+    ADMIN
+}

--- a/src/main/java/com/dedication/force/repository/MemberRepository.java
+++ b/src/main/java/com/dedication/force/repository/MemberRepository.java
@@ -9,4 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Boolean existsByEmail(String email);
     Boolean existsByPhone(String phone);
+
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/dedication/force/repository/MemberRoleRepository.java
+++ b/src/main/java/com/dedication/force/repository/MemberRoleRepository.java
@@ -1,0 +1,7 @@
+package com.dedication.force.repository;
+
+import com.dedication.force.domain.entity.MemberRole;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRoleRepository extends JpaRepository<MemberRole, Long> {
+}

--- a/src/main/java/com/dedication/force/repository/RoleRepository.java
+++ b/src/main/java/com/dedication/force/repository/RoleRepository.java
@@ -1,0 +1,11 @@
+package com.dedication.force.repository;
+
+import com.dedication.force.domain.entity.Role;
+import com.dedication.force.domain.entity.RoleType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+    Optional<Role> findByRoleType(RoleType roleType);
+}

--- a/src/main/java/com/dedication/force/service/MemberRoleService.java
+++ b/src/main/java/com/dedication/force/service/MemberRoleService.java
@@ -1,0 +1,8 @@
+package com.dedication.force.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class MemberRoleService {
+
+}

--- a/src/main/java/com/dedication/force/service/MemberService.java
+++ b/src/main/java/com/dedication/force/service/MemberService.java
@@ -1,10 +1,17 @@
 package com.dedication.force.service;
 
 import com.dedication.force.common.exception.CustomAPIException;
+import com.dedication.force.common.exception.CustomDataNotFoundException;
+import com.dedication.force.common.exception.CustomForbiddenException;
+import com.dedication.force.common.jwt.JwtTokenProvider;
+import com.dedication.force.common.jwt.JwtTokenRequest;
 import com.dedication.force.domain.dto.AddMemberRequest;
-import com.dedication.force.domain.entity.Member;
-import com.dedication.force.domain.entity.QMember;
+import com.dedication.force.domain.dto.LoginMemberRequest;
+import com.dedication.force.domain.dto.LoginMemberResponse;
+import com.dedication.force.domain.entity.*;
 import com.dedication.force.repository.MemberRepository;
+import com.dedication.force.repository.MemberRoleRepository;
+import com.dedication.force.repository.RoleRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -15,13 +22,16 @@ import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import static com.dedication.force.domain.entity.QMember.member;
-
 @RequiredArgsConstructor
 @Service
 public class MemberService {
 
     private final MemberRepository memberRepository;
+    private final RoleRepository roleRepository;
+    private final MemberRoleRepository memberRoleRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    private final TokenStorageService tokenStorageService;
 
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
     private final JPAQueryFactory queryFactory;
@@ -34,18 +44,30 @@ public class MemberService {
     public void checkMemberEmail(String email) {
         Matcher emailRex = Pattern.compile(EMAIL_PATTERN).matcher(email);
 
-        if (email.isEmpty()) {throw new CustomAPIException("이메일은 필수 입력입니다.");}
-        if (!emailRex.matches()) {throw new CustomAPIException("잘못된 이메일 입니다.");}
-        if (memberRepository.existsByEmail(email)) {throw new CustomAPIException("이미 가입된 이메일 입니다.");}
+        if (email.isEmpty()) {
+            throw new CustomAPIException("이메일은 필수 입력입니다.");
+        }
+        if (!emailRex.matches()) {
+            throw new CustomAPIException("잘못된 이메일 입니다.");
+        }
+        if (memberRepository.existsByEmail(email)) {
+            throw new CustomAPIException("이미 가입된 이메일 입니다.");
+        }
     }
 
     // 전화번호 중복 확인하기
     public void checkMemberPhone(String phone) {
         Matcher phoneRex = Pattern.compile(PHONE_PATTERN).matcher(phone);
 
-        if (phone.isEmpty()) {throw new CustomAPIException("휴대전화번호는 필수 입력입니다.");}
-        if (!phoneRex.matches()) {throw new CustomAPIException("잘못된 휴대전화번호 입니다.");}
-        if (memberRepository.existsByPhone(phone)) {throw new CustomAPIException("이미 가입된 휴대전화번호 입니다.");}
+        if (phone.isEmpty()) {
+            throw new CustomAPIException("휴대전화번호는 필수 입력입니다.");
+        }
+        if (!phoneRex.matches()) {
+            throw new CustomAPIException("잘못된 휴대전화번호 입니다.");
+        }
+        if (memberRepository.existsByPhone(phone)) {
+            throw new CustomAPIException("이미 가입된 휴대전화번호 입니다.");
+        }
     }
 
     // 회원 등록
@@ -63,11 +85,50 @@ public class MemberService {
         );
 
         memberRepository.save(member);
+
+        Role role = roleRepository.findByRoleType(RoleType.USER)
+                .orElseThrow(() -> new CustomAPIException("잘못된 권한입니다."));
+
+        MemberRole memberRole = new MemberRole();
+        memberRole.setMember(member);
+        memberRole.setRole(role);
+    }
+
+    // 회원 로그인
+    @Transactional
+    public LoginMemberResponse login(LoginMemberRequest request) {
+        Member member = memberRepository.findByEmail(request.email())
+                .orElseThrow(() -> new CustomDataNotFoundException("잘못된 아이디입니다."));
+
+        if (!bCryptPasswordEncoder.matches(request.password(), member.getPassword())) {
+            throw new CustomForbiddenException("잘못된 비밀번호입니다.");
+        }
+
+        List<String> roles = member.getMemberRoles().stream()
+                .map(memberRole -> memberRole.getRole().getRoleType().name())
+                .toList();
+
+        JwtTokenRequest jwtTokenRequest = JwtTokenRequest.builder()
+                .memberId(member.getId())
+                .email(member.getEmail())
+                .roles(roles)
+                .build();
+
+        String accessToken = jwtTokenProvider.createAccessToken(jwtTokenRequest);
+        String refreshToken = jwtTokenProvider.createRefreshToken(jwtTokenRequest);
+
+        tokenStorageService.addToken(refreshToken, "refresh_token");
+
+        return LoginMemberResponse.builder()
+                .memberId(member.getId())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
     }
 
     // 모든 회원 조회
     @Transactional
-    public List<Member> allMember() {
+    public List<Member> findAllMember() {
         QMember qMember = QMember.member; //기본 인스턴스 사용
 
         return queryFactory.selectFrom(qMember)
@@ -80,4 +141,12 @@ public class MemberService {
 
     // 회원 삭제
 
+    // 이메일로 회원 검색하기
+    public Member findByEmail(String email) {
+        QMember qMember = QMember.member;
+
+        return queryFactory.selectFrom(qMember)
+                .where(qMember.email.eq(email))
+                .fetchOne();
+    }
 }

--- a/src/main/java/com/dedication/force/service/RoleService.java
+++ b/src/main/java/com/dedication/force/service/RoleService.java
@@ -1,0 +1,13 @@
+package com.dedication.force.service;
+
+import com.dedication.force.repository.RoleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class RoleService {
+
+    private final RoleRepository roleRepository;
+
+}


### PR DESCRIPTION
회원과 권한 엔티티 사이에 연관관계 엔티티를 추가했다. 한 명의 회원이 여러 개의 권한을 갖고 있을 수 있으며 권한 추가하거나 제거하는 등 관리하는데 용이하기 때문이다. 그리고 스프링 시큐리티 내에서도 권한은 List 형식으로 처리하기 때문이다.

MemberService 안에는 회원 로그인 메서드가 있다. 로그인을 시도하면 시나리오는 다음과 같다.

1. 아이디 / 비밀번호 확인하기
2. 로그인한 회원 권한들을 List 에 저장하기
3. JWT 토큰 생생에 필요한 id, email, roles 를 JWT DTO 에 저장하기
4. JWT DTO 를 통해 액세스 토큰, 리프레시 토큰 생성하기
5. 토큰 저장소에 리프레시 토큰 저장하기
6. 로그인에 성공한 회원의 정보와 토큰들을 DTO로 응답하기

그리고 모든 회원 조회 allMember 에서 FindAllMember 로 변경하면서 더욱 직관적인 네이밍을 가질 수 있도록 변경했다.

This closes #16 