### PR TITLE
회원 로그인 기능 구현하기

### DIFF
--- a/src/main/java/com/dedication/force/controller/AuthController.java
+++ b/src/main/java/com/dedication/force/controller/AuthController.java
@@ -2,6 +2,8 @@ package com.dedication.force.controller;
 
 import com.dedication.force.common.HttpResponse;
 import com.dedication.force.domain.dto.AddMemberRequest;
+import com.dedication.force.domain.dto.LoginMemberRequest;
+import com.dedication.force.domain.dto.LoginMemberResponse;
 import com.dedication.force.domain.entity.Member;
 import com.dedication.force.service.MemberService;
 import jakarta.validation.Valid;
@@ -22,16 +24,26 @@ public class AuthController {
     private final MemberService memberService;
 
     // 회원 등록
-    @PostMapping("")
+    @PostMapping("/signup")
     public ResponseEntity<HttpResponse<Void>> addMember(@RequestBody @Valid AddMemberRequest request, BindingResult result) {
         memberService.addMember(request);
         return new ResponseEntity<>(new HttpResponse<>(1, "회원가입에 성공했습니다.", null), HttpStatus.CREATED);
     }
 
+    // 회원 로그인
+    @PostMapping("/login")
+    public ResponseEntity<HttpResponse<LoginMemberResponse>> login(@RequestBody @Valid LoginMemberRequest request, BindingResult result) {
+        LoginMemberResponse loginMemberResponse = memberService.login(request);
+        return new ResponseEntity<>(new HttpResponse<>(1, " 로그인에 성공했습니다.", loginMemberResponse), HttpStatus.CREATED);
+    }
+
+    // 회원 로그아웃
+
+
     // 모든 회원 조회
     @GetMapping("")
-    public ResponseEntity<HttpResponse<List<Member>>> allMember() {
-        return new ResponseEntity<>(new HttpResponse<>(1, "모든 회원 조회입니다.", memberService.allMember()), HttpStatus.OK);
+    public ResponseEntity<HttpResponse<List<Member>>> findAllMember() {
+        return new ResponseEntity<>(new HttpResponse<>(1, "모든 회원 조회입니다.", memberService.findAllMember()), HttpStatus.OK);
     }
 
     // 단건 회원 조회(id)
@@ -43,4 +55,8 @@ public class AuthController {
     // 회원 수정
 
     // 회원 삭제
+
+    // JWT 엑세스 토큰 재발급
+
+    // JWT 리프레시 토큰 재발급
 }

--- a/src/main/java/com/dedication/force/domain/dto/LoginMemberRequest.java
+++ b/src/main/java/com/dedication/force/domain/dto/LoginMemberRequest.java
@@ -1,0 +1,18 @@
+package com.dedication.force.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record LoginMemberRequest(
+        @NotBlank(message = "이메일: 필수 정보입니다.")
+        @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$", message = "이메일: 유효한 이메일 주소를 입력해주세요.")
+        @Size(min = 6, max = 32, message = "이메일: 유효한 이메일 주소를 입력해주세요.")
+        String email,
+
+        @NotBlank(message = "비밀번호: 필수 정보입니다.")
+        @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}"
+                , message = "비밀번호: 8~20자 영문 대소문자, 숫자, 특수문자를 조합하여 작성해야 합니다.")
+        @Size(min = 8, max = 20, message = "비밀번호: 8~20자 영문 대소문자, 숫자, 특수문자를 조합하여 작성해야 합니다.")
+        String password
+) { }

--- a/src/main/java/com/dedication/force/domain/dto/LoginMemberResponse.java
+++ b/src/main/java/com/dedication/force/domain/dto/LoginMemberResponse.java
@@ -1,0 +1,13 @@
+package com.dedication.force.domain.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class LoginMemberResponse {
+    // GPT 직렬화 이슈 - Getter 를 붙여야 한다.
+    private Long memberId;
+    private String accessToken;
+    private String refreshToken;
+}


### PR DESCRIPTION
 회원 컨트롤러 작성하기
 회원 요청, 응답 DTO 작성하기
 회원 로그인 엔드포인트 작성하기
 
 로그인에 시도하는 email, password 에 대해 유효성 검사를 수행한다. 회원가입 유효성 검사와 동일하게 적용했다.

로그인에 성공하면 응답으로 회원 고유 식별 번호, 액세스, 리프레시 토큰을 응답한다. LoginMemberResponse 클래스에 Getter 를 사용하지 않아서 직렬화가 안되는 문제가 있었다. Getter 가 필요한 이유에 대해 조사했다.

## 응답 DTO 에 Getter 가 필요한 이유

 Spring Boot에서는 기본적으로 객체를 JSON으로 변환할 때 Jackson 라이브러리를 사용합니다. 이 과정에서는 객체의 필드들을 JSON으로 변환할 수 있어야 하는데, LoginMemberResponse 클래스에서 직렬화를 위한 방법이 설정되어 있지 않아 발생하는 문제입니다.

해결 방법으로는 다음과 같은 접근이 있습니다:

DTO 클래스에 직렬화를 위한 설정 추가: LoginMemberResponse 클래스에는 직렬화를 위한 설정을 추가하여 Jackson이 객체를 JSON으로 변환할 수 있도록 합니다.
JsonIgnore 또는 JsonProperty 어노테이션 사용: 필요에 따라 무시해야 할 필드나 JSON에서 다른 이름으로 사용할 필드를 지정할 수 있습니다.
직렬화 오류 무시 설정 변경: Jackson의 SerializationFeature를 설정하여 빈 객체에 대한 예외를 무시하도록 변경할 수도 있습니다.

가장 일반적인 방법으로는 LoginMemberResponse 클래스에 @getter와 함께 @NoArgsConstructor, @AllArgsConstructor를 사용합니다.

This closes #17 