### PR TITLE
JWT 토큰 적용하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,10 @@ dependencies {
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
+	// 6. jjwt
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/dedication/force/common/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dedication/force/common/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,77 @@
+package com.dedication.force.common.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final UserDetailsService customUserDetailsService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String accessToken = getTokenFromRequest(request);
+
+        if (accessToken != null && jwtTokenProvider.validateToken(accessToken, jwtTokenProvider.getACCESS_TOKEN_SECRET_KEY())) {
+            // Access Token이 유효한 경우,
+            authenticateWithToken(accessToken, jwtTokenProvider.getACCESS_TOKEN_SECRET_KEY(), request);
+        } else {
+            // Access Token이 유효하지 않은 경우, Refresh Token을 검사
+            String refreshToken = getRefreshTokenFromRequest(request);
+            if (refreshToken != null && jwtTokenProvider.validateToken(refreshToken, jwtTokenProvider.getREFRESH_TOKEN_SECRET_KEY())) {
+                // Refresh Token이 유효한 경우, 새로운 Access Token 발급
+                String email = jwtTokenProvider.getEmailFromToken(refreshToken, jwtTokenProvider.getREFRESH_TOKEN_SECRET_KEY());
+
+                // 새로운 Access Token 발급 로직을 서비스에서 호출
+                UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+                String newAccessToken = jwtTokenProvider.createAccessToken(new JwtTokenRequest(userDetails));
+
+                response.setHeader("Authorization", "Bearer " + newAccessToken);
+                authenticateWithToken(newAccessToken, jwtTokenProvider.getACCESS_TOKEN_SECRET_KEY(), request);
+            }
+        }
+
+        // Refresh Token이 유효하지 않은 경우는 JwtAuthenticationFilter 클래스에서 validateToken 메서드의 반환 값이 false일 때 처리됩니다. 코드의 흐름상 validateToken 메서드가 false를 반환하면 아무 작업도 수행되지 않으며, 다음 필터로 넘어가게 됩니다.
+        // 여기서 refreshToken이 null이거나 validateToken 메서드가 false를 반환하면, filterChain.doFilter(request, response)를 호출하게 되어 다음 필터로 넘어갑니다. 즉, 인증이 이루어지지 않은 상태로 요청이 처리되며, 이후 Security 설정에 따라 접근이 제한됩니다.
+        filterChain.doFilter(request, response);
+    }
+
+    private void authenticateWithToken(String token, byte[] secretKey, HttpServletRequest request) {
+        String email = jwtTokenProvider.getEmailFromToken(token, secretKey);
+        UserDetails userDetails = customUserDetailsService.loadUserByUsername(email);
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+        authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    private String getTokenFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        log.info("getTokenFromRequest: {}", bearerToken);
+        return null;
+    }
+
+    private String getRefreshTokenFromRequest(HttpServletRequest request) {
+        // Refresh Token 을 어디서 가져올지는 결정해야 합니다.
+        // 예를 들어, 쿠키에서 가져올 수도 있습니다.
+        return request.getHeader("Refresh-Token");
+    }
+}

--- a/src/main/java/com/dedication/force/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dedication/force/common/jwt/JwtTokenProvider.java
@@ -1,0 +1,113 @@
+package com.dedication.force.common.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.UUID;
+import java.util.function.Function;
+
+@Slf4j
+@Getter
+@Component
+public class JwtTokenProvider {
+
+    private final byte[] ACCESS_TOKEN_SECRET_KEY;
+    private final byte[] REFRESH_TOKEN_SECRET_KEY;
+
+    public final static Long ACCESS_TOKEN_EXPIRE_COUNT = 30 * 60 * 1000L; // 30 minutes
+    public final static Long REFRESH_TOKEN_EXPIRE_COUNT = 7 * 24 * 60 * 60 * 1000L; // 7 days
+
+    public JwtTokenProvider(@Value("${jwt.key.access}") String accessSecret,
+                            @Value("${jwt.key.refresh}") String refreshSecret) {
+        this.ACCESS_TOKEN_SECRET_KEY = accessSecret.getBytes(StandardCharsets.UTF_8);
+        this.REFRESH_TOKEN_SECRET_KEY = refreshSecret.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public String createAccessToken(JwtTokenRequest request) {
+        return createToken(request, ACCESS_TOKEN_SECRET_KEY, ACCESS_TOKEN_EXPIRE_COUNT, "access-token");
+    }
+
+    public String createRefreshToken(JwtTokenRequest request) {
+        return createToken(request, REFRESH_TOKEN_SECRET_KEY, REFRESH_TOKEN_EXPIRE_COUNT, "refresh-token");
+    }
+
+    private String createToken(JwtTokenRequest request, byte[] secretKey, Long validityDuration, String tokenType) {
+        ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
+        ZonedDateTime validityDate = now.plus(Duration.ofMillis(validityDuration));
+
+        String jti = UUID.randomUUID().toString();
+
+        Claims claims = Jwts.claims().setSubject(request.getEmail());
+        claims.put("userId", request.getMemberId());
+        claims.put("tokenType", tokenType);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuer("force")
+                .setSubject(request.getEmail())
+                .setAudience("http://localhost:8080")
+                .setExpiration(Date.from(validityDate.toInstant()))
+                .setNotBefore(Date.from(now.toInstant()))
+                .setIssuedAt(Date.from(now.toInstant()))
+                .setId(jti)
+                .signWith(getSigningKey(secretKey))
+                .compact();
+    }
+
+    private Key getSigningKey(byte[] secretKey) {
+        return Keys.hmacShaKeyFor(secretKey);
+    }
+
+    public <T> T getClaimFromToken(String token, Function<Claims, T> claimsResolver, byte[] secretKey) {
+        final Claims claims = Jwts.parserBuilder()
+                .setSigningKey(getSigningKey(secretKey))
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+
+        return claimsResolver.apply(claims);
+    }
+
+    public String getEmailFromToken(String token, byte[] secretKey) {
+        return getClaimFromToken(token, Claims::getSubject, secretKey);
+    }
+
+    public String getTokenTypeFromToken(String token, byte[] secretKey) {
+        return getClaimFromToken(token, claims -> claims.get("tokenType", String.class), secretKey);
+    }
+
+    public Boolean validateToken(String token, byte[] secretKey) {
+        try {
+            Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey(secretKey))
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+            return true;
+        } catch (SecurityException e) {
+            log.error("유효하지 않은 JWT 서명입니다: {}", e.getMessage());
+        } catch (MalformedJwtException e) {
+            log.error("유효하지 않은 JWT 형식입니다: {}", e.getMessage());
+        } catch (ExpiredJwtException e) {
+            log.warn("만료된 JWT 토큰입니다: {}", e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            log.error("지원하지 않는 JWT 토큰입니다: {}", e.getMessage());
+        } catch (MissingClaimException e) {
+            log.error("필수 클레임이 누락되었습니다: {}", e.getMessage());
+        } catch (JwtException e) {
+            log.error("유효하지 않은 JWT 토큰입니다: {}", e.getMessage());
+        }
+        return false;
+    }
+
+}

--- a/src/main/java/com/dedication/force/common/jwt/JwtTokenRequest.java
+++ b/src/main/java/com/dedication/force/common/jwt/JwtTokenRequest.java
@@ -1,0 +1,31 @@
+package com.dedication.force.common.jwt;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Getter
+public class JwtTokenRequest {
+    private Long memberId;
+    private String email;
+    private List<String> roles;
+
+    @Builder
+    public JwtTokenRequest(Long memberId, String email, List<String> roles) {
+        this.memberId = memberId;
+        this.email = email;
+        this.roles = roles;
+    }
+
+    public JwtTokenRequest(UserDetails userDetails) {
+        this.email = userDetails.getUsername();
+        this.roles = userDetails.getAuthorities().stream()
+                .map(GrantedAuthority::getAuthority)
+                .toList();
+    }
+}

--- a/src/main/java/com/dedication/force/common/jwt/TokenType.java
+++ b/src/main/java/com/dedication/force/common/jwt/TokenType.java
@@ -1,0 +1,13 @@
+package com.dedication.force.common.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TokenType {
+    ACCESS_TOKEN("액세스 토큰"),
+    REFRESH_TOKEN("리프레시 토큰");
+
+    public final String token;
+}

--- a/src/main/java/com/dedication/force/common/security/CustomUserDetails.java
+++ b/src/main/java/com/dedication/force/common/security/CustomUserDetails.java
@@ -1,0 +1,55 @@
+package com.dedication.force.common.security;
+
+import com.dedication.force.domain.entity.Member;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@RequiredArgsConstructor
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return member.getMemberRoles()
+                .stream()
+                .map(memberRole -> new SimpleGrantedAuthority(memberRole.getRole().getRoleType().name()))
+                .toList();
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/com/dedication/force/common/security/CustomUserDetailsService.java
+++ b/src/main/java/com/dedication/force/common/security/CustomUserDetailsService.java
@@ -1,0 +1,30 @@
+package com.dedication.force.common.security;
+
+import com.dedication.force.domain.entity.Member;
+import com.dedication.force.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    // CustomUserDetailsService: 스프링 시큐리티와 연동하여 사용자 인증 및 권한 관리를 처리합니다.
+    // 시큐리티로 로그인이 될때, 시큐리티가 loadUserByUsername() 실행해서 username 을 체크!!
+    // 없으면 오류
+    // 있으면 정상적으로 시큐리티 컨텍스트 내부 세션에 로그인된 세션이 만들어진다.
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(username)
+                .orElseThrow(() -> new InternalAuthenticationServiceException("인증 실패"));
+        // UsernameNotFoundException 으로 처리할지 고민해보자.
+
+        return new CustomUserDetails(member);
+    }
+}

--- a/src/main/java/com/dedication/force/domain/dto/AddTokenRequest.java
+++ b/src/main/java/com/dedication/force/domain/dto/AddTokenRequest.java
@@ -1,0 +1,11 @@
+package com.dedication.force.domain.dto;
+
+import lombok.Builder;
+
+import java.util.Date;
+
+public record AddTokenRequest(String token, String tokenType, Date createdAt) {
+
+    @Builder
+    public AddTokenRequest {}
+}

--- a/src/main/java/com/dedication/force/domain/entity/TokenStorage.java
+++ b/src/main/java/com/dedication/force/domain/entity/TokenStorage.java
@@ -1,0 +1,35 @@
+package com.dedication.force.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class TokenStorage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 512, nullable = false)
+    private String token;
+
+    private String tokenType;
+
+    private Date createdAt;
+
+    @Builder
+    public TokenStorage(String token, String tokenType) {
+        this.token = token;
+        this.tokenType = tokenType;
+        this.createdAt = Date.from(ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toInstant());
+    }
+}

--- a/src/main/java/com/dedication/force/repository/TokenStorageRepository.java
+++ b/src/main/java/com/dedication/force/repository/TokenStorageRepository.java
@@ -1,0 +1,7 @@
+package com.dedication.force.repository;
+
+import com.dedication.force.domain.entity.TokenStorage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TokenStorageRepository extends JpaRepository<TokenStorage, Long> {
+}

--- a/src/main/java/com/dedication/force/service/TokenStorageService.java
+++ b/src/main/java/com/dedication/force/service/TokenStorageService.java
@@ -1,0 +1,22 @@
+package com.dedication.force.service;
+
+import com.dedication.force.domain.entity.TokenStorage;
+import com.dedication.force.repository.TokenStorageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class TokenStorageService {
+
+    private final TokenStorageRepository tokenStorageRepository;
+
+    public void addToken(String token, String tokenType) {
+        TokenStorage tokenStorage = TokenStorage.builder()
+                .token(token)
+                .tokenType(tokenType)
+                .build();
+
+        tokenStorageRepository.save(tokenStorage);
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -16,3 +16,11 @@ spring:
 logging.level:
   org.hibernate.SQL: debug
 #  org.hibernate.type: trace
+
+
+---
+
+jwt:
+  key:
+    access: rkGU45258GGhiolLO2465TFY5345kGU45258GGhiolLO2465TFY5345
+    refresh: rkGU45258GGhiolLO2465TFY5345kGU45258GGhiolLO2465TFY5345


### PR DESCRIPTION
JWT 라이브러리는 다양하다. 그 중에서 github 에서 가장 많은 start 를 받은 jjwt 라이브러리를 사용한다. 버전은 가장 안정적이고 최신 버전인 0.11.5 이다.

* 현재 PR 안에서만 주석을 포함하고, 다음 커밋에서 모든 주석은 제거가 될 것이다.

액세스 토큰과 리프레시 토큰 시크릿 키는 모두 application.yml 에서 관리하고, 30분, 7일의 만료 시간을 갖고 있다. 그리고 시크릿 키는 byte[] 배열을 사용하여 String 보다 더 높은 안전성을 보장하려고 타입을 지정했다.

JwtTokenRequest DTO 를 생성해서 토큰 생성에 필요한 정보를 DTO 로 생성해서 provider 와 분리했다. 추후에 더 추가될 정보가 있을지도 모르기 때문에 JWT 생성 DTO 를 구현했다.

액세스 토큰과 리프레시 토큰 안에 서로 동일한 정보를 포함할지, 말지 고민이었다. 서로 목적이 뚜렷하게 다르기 때문에 목적에 따라서 정보를 다르게 갖도록 설정하려고 생각했는데, chatGPT 는 동일한 정보를 갖는 것이 좋다고 답변을 받았다. 답변은 아래와 같다.

---

## 액세스 토큰과 리프레시 토큰 정보가 동일한 게 좋을까?
액세스 토큰과 리프레시 토큰이 포함해야 하는 정보에 대해 동일한 구성을 사용하는 것이 좋은 경우가 많습니다. 여기에는 몇 가지 이유가 있습니다:

일관성 유지: 액세스 토큰과 리프레시 토큰이 동일한 구조와 정보를 가지고 있다면, 클라이언트나 서버에서 이를 처리할 때 일관성을 유지하기 쉽습니다. 예를 들어, 토큰에서 사용자 식별 정보나 권한 정보를 추출하거나 검증할 때 일관성이 유지되어야 합니다.

보안 관리: 토큰의 구조가 동일하면, 보안 정책을 적용하거나 관리하는 데 더 효율적입니다. 예를 들어, 특정 데이터를 토큰에 추가하고 이를 검증하는 방법이 통일되어야 하므로, 구조적 일관성은 보안 관리를 강화할 수 있습니다.

유지보수와 확장성: 액세스 토큰과 리프레시 토큰이 동일한 구조를 가지면, 향후에 추가적인 필드나 변경사항을 쉽게 적용할 수 있습니다. 특정 필드가 필요하게 되더라도 기존의 구조를 변경하지 않고 새로운 필드를 추가하는 방식으로 유지보수가 용이합니다.

개발자 경험: 클라이언트 측에서도 동일한 방식으로 토큰을 처리할 수 있어 개발자 경험을 향상시킬 수 있습니다. 예를 들어, 토큰에서 추출해야 하는 정보가 일관되면 클라이언트 측 코드도 일관되게 작성할 수 있습니다.

따라서, 액세스 토큰과 리프레시 토큰의 구조와 포함해야 하는 정보가 가능한 동일하면서도 필요에 따라 액세스와 리프레시의 차이점을 명확히 나타낼 수 있는 방법을 선택하는 것이 좋습니다. 이는 보안, 유지보수성, 일관성 등 여러 측면에서 장점을 제공할 수 있습니다.

---

토큰 생성 전략은 등록된 클레임(Registered claims) 데이터를 포함하도록 작성했다. 가장 권하장하는 방식으로 개별적으로 정리한 JWT 이론 정리에서 구체적인 내용을 살펴볼 수 있다.
- https://limdae94.tistory.com/61

```
public <T> T getClaimFromToken(String token, Function<Claims, T> claimsResolver, byte[] secretKey) {}
```
getClaimFromToken메서드는 JWT 토큰에서 클레임을 추출하는 메서드이고, 각 매개변수의 의미는 다음과 같다.
- token : JWT 토큰 문자열
- claimsResolver: Claims 객체에서 클레임을 추출하는 함수로, Claims 객체를 입력으로 받아 원하는 타입 T의 값을 반환한다.
- secretkey : byte[] 배열 형태의 시크릿 키

Jwts.parserBuilder(): JWT 토큰을 파싱하기 위한 빌더 객체를 생성.
.setSigningKey(getSigningKey(secretKey)): 파서에 시크릿 키를 설정한다. getSigningKey(secretKey) 메서드는 주어진 바이트 배열 형태의 시크릿 키를 사용하여 키 객체를 생성한다.
.build(): 설정이 완료된 파서를 빌드하여 사용할 수 있는 상태로 생성한다.
.parseClaimsJws(token): 파서를 사용하여 주어진 토큰을 파싱하고, 서명을 검증한다. 이 과정에서 토큰이 유효하지 않으면 예외가 발생할 수 있다.
.getBody(): 파싱된 JWT의 본문(클레임)을 가져온다. getBody() 메서드는 Claims 객체를 반환한다.

claimsResolver.apply(claims): claimsResolver 함수를 사용하여 Claims 객체에서 원하는 타입 T의 값을 추출하고 반환한다. 이 함수는 클레임을 추출하는 방법을 정의하는 함수로, 예를 들어 Claims::getSubject와 같은 메서드 레퍼런스 방식으로 사용될 수 있다.

JWT 필터는 스프링 시큐리티 필터 체인에서 JWT 토큰을 검증하는 역할을 한다. 요청에서 JWT 토큰을 추출하고, 토큰이 유효한 경우 해당 사용자의 인증 정보를 설정한다.

JWT 필터 구현 사례들을 검색해서 살펴보면 BasicAuthenticationFilter 혹은 GenericFilterBean 을 상속 받는 경우가 흔히 있다. 해당 클래스 대신에 OncePerRequestFilter 를 상속 받아서 구현하는 이유는 다음과 같다.

1. 단일 실행 보장: 동일한 요청에서 필터가 여러 번 실행되지 않도록 하여 중복 인증을 방지한다.
2. 성능 최적화: 중복된 인증 절차를 제거하여 시스템 성능을 향상시킨다.
3. 보안 유지: 모든 요청에 대해 동일한 보안 필터를 적용하되, 불필요한 중복 실행을 방지한다.

오버라이드된 doFilterInternal 메서드 안을 살펴보면,
1. 액세스 토큰을 가져와서 유효한지,
2. 액세스 토큰이 유효하지 않다면 리프레시 토큰이 유효한지,
3. 리프레시 토큰이 유효하면 액세스 토큰 재발급

이때, 리프레시 토큰이 유효하지 않으면 JwtAuthenticationFilter 클래스에서 validateToken 메서드의 반환 값이 false일 때 처리된다. 코드의 흐름상 validateToken 메서드가 false를 반환하면 아무 작업도 수행되지 않으며, 다음 필터로 넘어가게 된다. 여기서 refreshToken이 null이거나 validateToken 메서드가 false를 반환하면, filterChain.doFilter(request, response)를 호출하게 되어 다음 필터로 넘어간다. 즉, 인증이 이루어지지 않은 상태로 요청이 처리되며, 이후 Security 설정에 따라 접근이 제한된다.

authenticateWithToken 메서드에서는 SecurityContextHolder 객체를 생성하고 회원 정보를 스프링 시큐리티 내부 세션으로 생성하여 회원 정보를 유지한다. 동작 과정은 간단하게 다음과 같다.
1. 토큰에서 이메일을 추출하여 UserDetails 객체를 가져온다.
2. UsernamePasswordAuthenticationToken을 생성하여 SecurityContextHolder에 설정한다.

getRefreshTokenFromRequest 메서드는 리프레시 토큰을 가져오는 메서드이다. Refresh Token 을 어디서 가져올지는 결정한다. 헤더로부터 가져오도록 구현했다.

액세스 토큰과 리프레시 토큰 생성에 필요한 정보를 포함하는 DTO 클래스.

UserDetails 클래스를 매개변수로 포함하는 생성자를 구현하여
스프링 시큐리티에 email, roles 등록한다.

CustomUserDetailsService 는 스프링 시큐리티와 연동하여 사용자 인증 및 권한 관리를 처리한다. 스프링 시큐리티 내부에서 회원를 확인하기 위해 loadUserByUsername() 실행해서 username 을 체크한다.
 - 회원 정보가 없으면 오류가 발생한다.
 - 회원 정보가 존재하면 정상적으로 시큐리티 컨텍스트 내부 세션에 로그인된 세션이 생성된다. loadUserByUsername 메서드에서 사용자 이메일로 사용자 정보를 가져와서 UserDetails 객체로 반환한다.

인증에 실패하면 발생되는 예외를 InternalAuthenticationServiceException 할지, UsernameNotFoundException 할지 고민이다.

CustomUserDetails 는 스프링 시큐리티에서 사용자 정보를 갖고 있는 인터페이스이다. 로그인 완료하면 세션에 있는 유저정보 객체를 UserDetails 타입을 가지고있는 객체를 따로 만들어 저장시켜준다.

RDBMS(H2) 안에 저장하고 리프레시 토큰을 저장했다. 배포와 함께 Redis 에서 리프레시 토큰 정책을 세우고 관리할 것이다.
토큰 고유 식별 번호, 토큰 문자열,  토큰 타입, 생성일자 정보가 포함되어 있다. 토큰 타입을 저장할지 말지 고민이다.

This closes #14
This closes #12 