### PR TITLE
스프링 시큐리티 로그인 예외 설정하기

### DIFF
--- a/src/main/java/com/dedication/force/common/config/WebConfig.java
+++ b/src/main/java/com/dedication/force/common/config/WebConfig.java
@@ -1,6 +1,5 @@
 package com.dedication.force.common.config;
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;

--- a/src/main/java/com/dedication/force/common/security/CustomJWTAccessDeniedHandler.java
+++ b/src/main/java/com/dedication/force/common/security/CustomJWTAccessDeniedHandler.java
@@ -1,0 +1,20 @@
+package com.dedication.force.common.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomJWTAccessDeniedHandler implements AccessDeniedHandler {
+
+    // AccessDeniedHandler 설정: 권한 부족 시 403 Forbidden 응답을 반환하는 Handler를 설정합니다.
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, "Forbidden");
+    }
+}

--- a/src/main/java/com/dedication/force/common/security/CustomJWTAuthenticationEntryPoint.java
+++ b/src/main/java/com/dedication/force/common/security/CustomJWTAuthenticationEntryPoint.java
@@ -1,0 +1,21 @@
+package com.dedication.force.common.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomJWTAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    // AuthenticationEntryPoint 설정: 인증 실패 시 401 Unauthorized 응답을 반환하는 EntryPoint를 설정합니다.
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
+    }
+
+}


### PR DESCRIPTION
로그인 성공과 실패에 따른 예외 메시지가 필요하다. 어떻게 로그인 / 로그아웃 메시지를 작성할 것인지 정해보자.

- 로그인 / 로그아웃 스프링 시큐리티 예외 작성하기
AccessDeniedHandler 는 권한으로 인해 접근 거부인 경우 403 Frobidden 으로 응답하는 Handler 이다.
AuthenticationEntryPoint 는 인증 실패 시 401 Unauthorized 으로 응답을 반환하는 EntryPoint 이다.

- 로그인 / 로그아웃 정책 세우기
로그인에 실패한 경우는 customJWTAuthenticationEntryPoint,
권한이 부족한 경우는 customJWTAccessDeniedHandler 에서 작성된 예외가 발생된다.

작성한 JWT 필터를 Spring Security 필터 체인에 추가한다.

AuthenticationManager 클래스를 추가한다. AuthenticationManager는 사용자의 인증을 처리하는 역할을 한다. 주로 사용자 이름과 비밀번호 또는 다른 인증 정보가 올바른지 확인하는 데 사용된다. SecurityConfig 클래스에서 authenticationManager 메서드를 정의하는 이유는, AuthenticationManager를 스프링 컨텍스트에서 빈으로 쉽게 사용할 수 있도록 하기 위함이다. 이로 인해 스프링 시큐리티 설정 내에서 인증 로직을 더 유연하게 사용할 수 있다.

This closes #13 