### PR TITLE
로그인과 토큰 재발급 구현하기

### DIFF
--- a/src/main/java/com/dedication/force/common/CustomExceptionHandler.java
+++ b/src/main/java/com/dedication/force/common/CustomExceptionHandler.java
@@ -1,9 +1,6 @@
 package com.dedication.force.common;
 
-import com.dedication.force.common.exception.CustomAPIException;
-import com.dedication.force.common.exception.CustomDataNotFoundException;
-import com.dedication.force.common.exception.CustomForbiddenException;
-import com.dedication.force.common.exception.CustomValidationException;
+import com.dedication.force.common.exception.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -45,4 +42,12 @@ public class CustomExceptionHandler {
         log.error(e.getMessage());
         return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), e.getErrorMap()), BAD_REQUEST);
     }
+
+    @ExceptionHandler(CustomJwtException.class)
+    @ResponseStatus(UNAUTHORIZED)
+    public ResponseEntity<HttpResponse<Void>> JWTException(CustomAPIException e) {
+        log.error(e.getMessage());
+        return new ResponseEntity<>(new HttpResponse<>(-1, e.getMessage(), null), UNAUTHORIZED);
+    }
+
 }

--- a/src/main/java/com/dedication/force/common/exception/CustomJwtException.java
+++ b/src/main/java/com/dedication/force/common/exception/CustomJwtException.java
@@ -1,0 +1,7 @@
+package com.dedication.force.common.exception;
+
+public class CustomJwtException extends RuntimeException{
+    public CustomJwtException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/dedication/force/common/security/CustomJWTAuthenticationEntryPoint.java
+++ b/src/main/java/com/dedication/force/common/security/CustomJWTAuthenticationEntryPoint.java
@@ -17,5 +17,4 @@ public class CustomJWTAuthenticationEntryPoint implements AuthenticationEntryPoi
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Unauthorized");
     }
-
 }

--- a/src/main/java/com/dedication/force/controller/AuthController.java
+++ b/src/main/java/com/dedication/force/controller/AuthController.java
@@ -1,10 +1,7 @@
 package com.dedication.force.controller;
 
 import com.dedication.force.common.HttpResponse;
-import com.dedication.force.domain.dto.AddMemberRequest;
-import com.dedication.force.domain.dto.LoginMemberRequest;
-import com.dedication.force.domain.dto.LoginMemberResponse;
-import com.dedication.force.domain.entity.Member;
+import com.dedication.force.domain.dto.*;
 import com.dedication.force.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -34,15 +31,21 @@ public class AuthController {
     @PostMapping("/login")
     public ResponseEntity<HttpResponse<LoginMemberResponse>> login(@RequestBody @Valid LoginMemberRequest request, BindingResult result) {
         LoginMemberResponse loginMemberResponse = memberService.login(request);
-        return new ResponseEntity<>(new HttpResponse<>(1, " 로그인에 성공했습니다.", loginMemberResponse), HttpStatus.CREATED);
+        return new ResponseEntity<>(new HttpResponse<>(1, " 로그인에 성공했습니다.", loginMemberResponse), HttpStatus.OK);
+    }
+
+    // JWT 토큰 재발급
+    @PostMapping("/token-reissue")
+    public ResponseEntity<HttpResponse<LoginMemberResponse>> refreshTokenReissue(@RequestBody RefreshTokenRequest request) {
+        LoginMemberResponse loginMemberResponse = memberService.refreshTokenReissue(request);
+        return new ResponseEntity<>(new HttpResponse<>(1, "토큰을 재발급 합니다.", loginMemberResponse), HttpStatus.OK);
     }
 
     // 회원 로그아웃
 
-
     // 모든 회원 조회
-    @GetMapping("")
-    public ResponseEntity<HttpResponse<List<Member>>> findAllMember() {
+    @GetMapping("/findAll")
+    public ResponseEntity<HttpResponse<List<MemberDto>>> findAllMember() {
         return new ResponseEntity<>(new HttpResponse<>(1, "모든 회원 조회입니다.", memberService.findAllMember()), HttpStatus.OK);
     }
 
@@ -55,8 +58,4 @@ public class AuthController {
     // 회원 수정
 
     // 회원 삭제
-
-    // JWT 엑세스 토큰 재발급
-
-    // JWT 리프레시 토큰 재발급
 }

--- a/src/main/java/com/dedication/force/domain/dto/MemberDto.java
+++ b/src/main/java/com/dedication/force/domain/dto/MemberDto.java
@@ -1,0 +1,23 @@
+package com.dedication.force.domain.dto;
+
+import com.dedication.force.domain.entity.Member;
+
+import java.time.ZonedDateTime;
+
+public record MemberDto(
+        Long id,
+        String email,
+        String phone,
+        ZonedDateTime createdAt,
+        ZonedDateTime modifiedAt) {
+
+    public MemberDto from(Member member) {
+        return new MemberDto(
+                member.getId(),
+                member.getEmail(),
+                member.getPhone(),
+                member.getCreatedAt(),
+                member.getModifiedAt()
+        );
+    }
+}

--- a/src/main/java/com/dedication/force/domain/dto/RefreshTokenRequest.java
+++ b/src/main/java/com/dedication/force/domain/dto/RefreshTokenRequest.java
@@ -1,0 +1,4 @@
+package com.dedication.force.domain.dto;
+
+public record RefreshTokenRequest(String refreshToken) {
+}

--- a/src/main/java/com/dedication/force/domain/dto/TokenStorageDto.java
+++ b/src/main/java/com/dedication/force/domain/dto/TokenStorageDto.java
@@ -1,0 +1,24 @@
+package com.dedication.force.domain.dto;
+
+import com.dedication.force.common.jwt.TokenType;
+import com.dedication.force.domain.entity.TokenStorage;
+
+import java.util.Date;
+
+public record TokenStorageDto(Long id, String token, TokenType tokenType, Date createdAt) {
+
+    public TokenStorage toEntity() {
+        return TokenStorage.builder()
+                .token(token)
+                .tokenType(tokenType)
+                .build();
+    }
+
+    public static TokenStorageDto from(TokenStorage tokenStorage) {
+        return new TokenStorageDto(
+                tokenStorage.getId(),
+                tokenStorage.getToken(),
+                tokenStorage.getTokenType(),
+                tokenStorage.getCreatedAt());
+    }
+}

--- a/src/main/java/com/dedication/force/domain/entity/Member.java
+++ b/src/main/java/com/dedication/force/domain/entity/Member.java
@@ -1,5 +1,6 @@
 package com.dedication.force.domain.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -31,12 +32,15 @@ public class Member {
 
     private ZonedDateTime modifiedAt;
 
+    @JsonIgnore
     @OneToMany(mappedBy = "member", cascade = {CascadeType.ALL})
     private final List<Article> articles = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "member", cascade = {CascadeType.ALL})
     private final List<Comment> comments = new ArrayList<>();
 
+    @JsonIgnore
     @OneToMany(mappedBy = "member", cascade = {CascadeType.ALL})
     private final List<MemberRole> memberRoles = new ArrayList<>();
 

--- a/src/main/java/com/dedication/force/domain/entity/TokenStorage.java
+++ b/src/main/java/com/dedication/force/domain/entity/TokenStorage.java
@@ -1,5 +1,6 @@
 package com.dedication.force.domain.entity;
 
+import com.dedication.force.common.jwt.TokenType;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -22,14 +23,16 @@ public class TokenStorage {
     @Column(length = 512, nullable = false)
     private String token;
 
-    private String tokenType;
+    @Enumerated(EnumType.STRING)
+    private TokenType tokenType;
 
     private Date createdAt;
 
     @Builder
-    public TokenStorage(String token, String tokenType) {
+    public TokenStorage(String token, TokenType tokenType) {
         this.token = token;
         this.tokenType = tokenType;
         this.createdAt = Date.from(ZonedDateTime.now(ZoneId.of("Asia/Seoul")).toInstant());
     }
+
 }

--- a/src/main/java/com/dedication/force/repository/TokenStorageRepository.java
+++ b/src/main/java/com/dedication/force/repository/TokenStorageRepository.java
@@ -3,5 +3,9 @@ package com.dedication.force.repository;
 import com.dedication.force.domain.entity.TokenStorage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TokenStorageRepository extends JpaRepository<TokenStorage, Long> {
+
+    Optional<TokenStorage> findByToken(String token);
 }

--- a/src/main/java/com/dedication/force/service/TokenStorageService.java
+++ b/src/main/java/com/dedication/force/service/TokenStorageService.java
@@ -1,5 +1,8 @@
 package com.dedication.force.service;
 
+import com.dedication.force.common.exception.CustomJwtException;
+import com.dedication.force.common.jwt.TokenType;
+import com.dedication.force.domain.dto.TokenStorageDto;
 import com.dedication.force.domain.entity.TokenStorage;
 import com.dedication.force.repository.TokenStorageRepository;
 import lombok.RequiredArgsConstructor;
@@ -11,12 +14,19 @@ public class TokenStorageService {
 
     private final TokenStorageRepository tokenStorageRepository;
 
-    public void addToken(String token, String tokenType) {
+    public void addToken(String token, TokenType tokenType) {
         TokenStorage tokenStorage = TokenStorage.builder()
                 .token(token)
                 .tokenType(tokenType)
                 .build();
 
         tokenStorageRepository.save(tokenStorage);
+    }
+
+    public TokenStorageDto findToken(String token) {
+        TokenStorage tokenStorage = tokenStorageRepository.findByToken(token)
+                .orElseThrow(() -> new CustomJwtException("존재하지 않는 토큰입니다."));
+
+        return TokenStorageDto.from(tokenStorage);
     }
 }

--- a/src/test/java/com/dedication/force/ForceApplicationTests.java
+++ b/src/test/java/com/dedication/force/ForceApplicationTests.java
@@ -2,7 +2,9 @@ package com.dedication.force;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class ForceApplicationTests {
 

--- a/src/test/java/com/dedication/force/common/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/dedication/force/common/jwt/JwtAuthenticationFilterTest.java
@@ -17,14 +17,12 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.io.IOException;
-import java.util.Collections;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
 @DisplayName("[JWT] JwtAuthenticationFilter")
 @ActiveProfiles("test")
-class JwtAuthenticationFilterTest {
+class JwtAuthenticationFilterTest  {
 
 
     @Mock

--- a/src/test/java/com/dedication/force/common/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/dedication/force/common/jwt/JwtTokenProviderTest.java
@@ -209,5 +209,22 @@ class JwtTokenProviderTest {
         Assertions.assertThat(tokenTypeFromToken).isEqualTo("access-token");
     }
 
+    @DisplayName("[JWT 회원 권한 출력")
+    @Test
+    public void GivenToken_ExpectedGetRoles() {
+        // Given
+        JwtTokenRequest request = JwtTokenRequest.builder()
+                .memberId(1L)
+                .email("accessToken@naver.com")
+                .roles(List.of(RoleType.USER.toString()))
+                .build();
+
+        String accessToken = jwtTokenProvider.createAccessToken(request);
+
+        // Expected
+        List<String> memberRolesFromToken = jwtTokenProvider.getMemberRolesFromToken(accessToken, jwtTokenProvider.getACCESS_TOKEN_SECRET_KEY());
+        Assertions.assertThat(memberRolesFromToken.contains(RoleType.USER.toString())).isTrue();
+    }
+
 
 }

--- a/src/test/java/com/dedication/force/service/TokenStorageServiceTest.java
+++ b/src/test/java/com/dedication/force/service/TokenStorageServiceTest.java
@@ -1,0 +1,66 @@
+package com.dedication.force.service;
+
+import com.dedication.force.common.jwt.JwtTokenProvider;
+import com.dedication.force.common.jwt.JwtTokenRequest;
+import com.dedication.force.common.jwt.TokenType;
+import com.dedication.force.domain.dto.TokenStorageDto;
+import com.dedication.force.domain.entity.RoleType;
+import com.dedication.force.domain.entity.TokenStorage;
+import com.dedication.force.repository.TokenStorageRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+@DisplayName("[JWT] 서비스")
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@SpringBootTest
+class TokenStorageServiceTest {
+
+    @Autowired
+    private TokenStorageRepository tokenStorageRepository;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private TokenStorageService tokenStorageService;
+
+    @BeforeEach
+    public void clean() {
+        tokenStorageRepository.deleteAll();
+    }
+
+    @DisplayName("[JWT 단건 조회]: 토큰 조회하기")
+    @Test
+    public void GivenSavedRefreshToken_ExpectedSuccess() {
+        // given
+        JwtTokenRequest request = JwtTokenRequest.builder()
+                .memberId(1L)
+                .email("test@naver.com")
+                .roles(List.of(RoleType.USER.toString()))
+                .build();
+
+        String refreshToken = jwtTokenProvider.createRefreshToken(request);
+
+        TokenStorage tokenStorage = TokenStorage.builder()
+                .token(refreshToken)
+                .tokenType(TokenType.REFRESH_TOKEN)
+                .build();
+
+        tokenStorageRepository.save(tokenStorage);
+        TokenStorageDto findToken = tokenStorageService.findToken(refreshToken);
+
+        // Expected
+        Assertions.assertThat(findToken.token()).isEqualTo(refreshToken);
+        Assertions.assertThat(findToken.tokenType()).isEqualTo(TokenType.REFRESH_TOKEN);
+    }
+
+}


### PR DESCRIPTION
로그인에 성공할 때, 액세스 토큰과 리프레시 토큰을 발급해야 한다. 그리고 액세스 토큰 혹은 리프레시 토큰이 만료되는 것을 확인하고 재발급을 해주어야 한다. 단, 완전히 만료되기를 기다리는 것이 아니라 만료 기간이 임박할 때 발급해주자. 액세스 토큰의 경우는 만료 시간과 관계 없이 재발급되고, 리프레시 토큰만 만료 기간이 24시간 미만이면 발급이 가능하다.

- 로그인 구현하기
- 액세스 토큰, 리프레시 토큰 재발급 구현하기
- 로그인 테스트 코드 작성하기
- 액세스 토큰, 리프레시 토큰 재발급 테스트 구현하기
 
 **리프레시 토큰 재발급 이후에 다시 데이터베이스에 저장해야 할 필요가 있다. 다음 과제가 될 것이다.**



CustomJWTAuthenticationEntryPoint 에서 불필요한 공백을 제거했다.

새로운 예외 처리를 위해 CustomJwtException 을 구현했다.

토큰의 만료 시간이 임박하면 다시 재발급을 할 수 있도록 변경했다.

그리고 JWT 토큰으로부터 ID 와 권한을 찾을 수 있도록 변경했으며 JWT 토큰 validate 메서드 안을 더 가독성 좋게 변경했다.
 
 HTTP Body 안에 응답 데이터가 무한히 반복되는 순환 참조 문제가 발생했다. 이 문제를 해결하기 위해서는 엔티티 클래스의 필드 중에서 API 응답에 포함되지 않아야 할 필드에 @JsonIgnore 를 사용하여 해당 필드를 제외하는 것이다. 이 방법으로 HTTP Body 는 정상적으로 응답 데이터를 클라이언트에게 전송할 수 있었다.   또 다른 방법으로는 DTO 를 생성하는 것이다.

API 응답에는 DTO 를 사용하여 필요한 필드만 포함하도록 생성한다. DTO 를 사용하면 엔티티의 전체 그래프를 JSON 으로 변환하지 않고도 필요한 필드만을 선택적으로 포함할 수 있다.

HTTP Body 응답 데이터의 순환 참조 문제 해결을 위해 @JsonIgnore 와 DTO 클래스로 응답하는 두 가지 방식을 선택해서 사용하거나 둘 다 사용하면 된다.


토큰을 재발급 하기 위해서 만료 여부를 먼저 구현했다. 그리고 만료 여부가 임박한 토큰에 대해서도 발급될 수 있도록 기준이 되는 시간을 받아서 토큰을 재발급 할 수 있도록 변경했다.

단, 액세스 토큰의 경우는 바로 재발급이 되며 리프레시 토큰만 24 시간 미만인 경우에 재발급이 된다.

토큰 재발급 코드 작성에 따라 테스트 코드에 변경된 부분을 참고하자. 되도록 엔티티를 생성하지 않고, DTO 를 거쳐서 로직이 수행되도록 작성했다. 해당 테스트들은 실제로 비즈니스 로직에 포함되지 않는 코드이지만, 테스트 코드로 싑게 확인을 위해서 구현된 테스트들이다.

This closes #24 