### PR TITLE
댓글 도메인 분리하기

### DIFF
--- a/src/main/java/com/dedication/force/article/domain/entity/Article.java
+++ b/src/main/java/com/dedication/force/article/domain/entity/Article.java
@@ -1,22 +1,26 @@
-package com.dedication.force.member.domain.entity;
+package com.dedication.force.article.domain.entity;
 
-import com.dedication.force.article.domain.entity.Member;
+import com.dedication.force.member.domain.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import java.time.ZonedDateTime;
+import java.util.Set;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Comment {
+public class Article {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "comment_id", nullable = false, updatable = false)
+    @Column(name = "article_id", nullable = false, updatable = false)
     private Long id;
 
-    @Column(length = 200, nullable = false)
+    @Column(length = 50, nullable = false)
+    private String title;
+
+    @Column(length = 3000, nullable = false)
     private String content;
 
     @Column(nullable = false)
@@ -28,4 +32,7 @@ public class Comment {
     @JoinColumn(name = "member_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<ArticleCategory> articleCategories;
 }

--- a/src/main/java/com/dedication/force/article/domain/entity/ArticleCategory.java
+++ b/src/main/java/com/dedication/force/article/domain/entity/ArticleCategory.java
@@ -1,4 +1,4 @@
-package com.dedication.force.member.domain.entity;
+package com.dedication.force.article.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/dedication/force/article/domain/entity/Category.java
+++ b/src/main/java/com/dedication/force/article/domain/entity/Category.java
@@ -1,4 +1,4 @@
-package com.dedication.force.member.domain.entity;
+package com.dedication.force.article.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/dedication/force/article/repository/ArticleRepository.java
+++ b/src/main/java/com/dedication/force/article/repository/ArticleRepository.java
@@ -1,6 +1,6 @@
 package com.dedication.force.article.repository;
 
-import com.dedication.force.member.domain.entity.Article;
+import com.dedication.force.article.domain.entity.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {

--- a/src/main/java/com/dedication/force/article/repository/CategoryRepository.java
+++ b/src/main/java/com/dedication/force/article/repository/CategoryRepository.java
@@ -1,6 +1,6 @@
 package com.dedication.force.article.repository;
 
-import com.dedication.force.member.domain.entity.Category;
+import com.dedication.force.article.domain.entity.Category;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {

--- a/src/main/java/com/dedication/force/comment/domain/entity/Comment.java
+++ b/src/main/java/com/dedication/force/comment/domain/entity/Comment.java
@@ -1,26 +1,22 @@
-package com.dedication.force.member.domain.entity;
+package com.dedication.force.comment.domain.entity;
 
-import com.dedication.force.article.domain.entity.Member;
+import com.dedication.force.member.domain.entity.Member;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
 import java.time.ZonedDateTime;
-import java.util.Set;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
-public class Article {
+public class Comment {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "article_id", nullable = false, updatable = false)
+    @Column(name = "comment_id", nullable = false, updatable = false)
     private Long id;
 
-    @Column(length = 50, nullable = false)
-    private String title;
-
-    @Column(length = 3000, nullable = false)
+    @Column(length = 200, nullable = false)
     private String content;
 
     @Column(nullable = false)
@@ -32,7 +28,4 @@ public class Article {
     @JoinColumn(name = "member_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
-
-    @OneToMany(mappedBy = "article", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Set<ArticleCategory> articleCategories;
 }

--- a/src/main/java/com/dedication/force/comment/repository/CommentRepository.java
+++ b/src/main/java/com/dedication/force/comment/repository/CommentRepository.java
@@ -1,6 +1,6 @@
-package com.dedication.force.article.repository;
+package com.dedication.force.comment.repository;
 
-import com.dedication.force.member.domain.entity.Comment;
+import com.dedication.force.comment.domain.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {

--- a/src/main/java/com/dedication/force/comment/service/CommentService.java
+++ b/src/main/java/com/dedication/force/comment/service/CommentService.java
@@ -1,6 +1,6 @@
-package com.dedication.force.article.service;
+package com.dedication.force.comment.service;
 
-import com.dedication.force.article.repository.CommentRepository;
+import com.dedication.force.comment.repository.CommentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/dedication/force/common/security/CustomUserDetails.java
+++ b/src/main/java/com/dedication/force/common/security/CustomUserDetails.java
@@ -1,6 +1,6 @@
 package com.dedication.force.common.security;
 
-import com.dedication.force.article.domain.entity.Member;
+import com.dedication.force.member.domain.entity.Member;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;

--- a/src/main/java/com/dedication/force/common/security/CustomUserDetailsService.java
+++ b/src/main/java/com/dedication/force/common/security/CustomUserDetailsService.java
@@ -1,6 +1,6 @@
 package com.dedication.force.common.security;
 
-import com.dedication.force.article.domain.entity.Member;
+import com.dedication.force.member.domain.entity.Member;
 import com.dedication.force.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;

--- a/src/main/java/com/dedication/force/member/controller/AuthController.java
+++ b/src/main/java/com/dedication/force/member/controller/AuthController.java
@@ -1,8 +1,8 @@
 package com.dedication.force.member.controller;
 
-import com.dedication.force.article.domain.dto.*;
 import com.dedication.force.common.HttpResponse;
 import com.dedication.force.common.jwt.dto.RefreshTokenRequest;
+import com.dedication.force.member.domain.dto.*;
 import com.dedication.force.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/dedication/force/member/domain/dto/AddMemberRequest.java
+++ b/src/main/java/com/dedication/force/member/domain/dto/AddMemberRequest.java
@@ -1,10 +1,12 @@
-package com.dedication.force.article.domain.dto;
+package com.dedication.force.member.domain.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 
-public record LoginMemberRequest(
+@Builder
+public record AddMemberRequest(
         @NotBlank(message = "이메일: 필수 정보입니다.")
         @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$", message = "이메일: 유효한 이메일 주소를 입력해주세요.")
         @Size(min = 6, max = 32, message = "이메일: 유효한 이메일 주소를 입력해주세요.")
@@ -14,5 +16,12 @@ public record LoginMemberRequest(
         @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}"
                 , message = "비밀번호: 8~20자 영문 대소문자, 숫자, 특수문자를 조합하여 작성해야 합니다.")
         @Size(min = 8, max = 20, message = "비밀번호: 8~20자 영문 대소문자, 숫자, 특수문자를 조합하여 작성해야 합니다.")
-        String password
-) { }
+        String password,
+
+        @NotBlank(message = "휴대전화번호: 필수 정보입니다.")
+        @Pattern(regexp = "^[0-9]{10,11}$", message = "휴대전화번호: 10~11자 숫자만 입력해주세요.")
+        @Size(min = 10, max = 11, message = "휴대전화번호: 10~11자 숫자만 입력해주세요.")
+        String phone
+) {
+
+}

--- a/src/main/java/com/dedication/force/member/domain/dto/LoginMemberRequest.java
+++ b/src/main/java/com/dedication/force/member/domain/dto/LoginMemberRequest.java
@@ -1,12 +1,10 @@
-package com.dedication.force.article.domain.dto;
+package com.dedication.force.member.domain.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
 
-@Builder
-public record AddMemberRequest(
+public record LoginMemberRequest(
         @NotBlank(message = "이메일: 필수 정보입니다.")
         @Pattern(regexp = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$", message = "이메일: 유효한 이메일 주소를 입력해주세요.")
         @Size(min = 6, max = 32, message = "이메일: 유효한 이메일 주소를 입력해주세요.")
@@ -16,12 +14,5 @@ public record AddMemberRequest(
         @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z])(?=.*\\W)(?=\\S+$).{8,20}"
                 , message = "비밀번호: 8~20자 영문 대소문자, 숫자, 특수문자를 조합하여 작성해야 합니다.")
         @Size(min = 8, max = 20, message = "비밀번호: 8~20자 영문 대소문자, 숫자, 특수문자를 조합하여 작성해야 합니다.")
-        String password,
-
-        @NotBlank(message = "휴대전화번호: 필수 정보입니다.")
-        @Pattern(regexp = "^[0-9]{10,11}$", message = "휴대전화번호: 10~11자 숫자만 입력해주세요.")
-        @Size(min = 10, max = 11, message = "휴대전화번호: 10~11자 숫자만 입력해주세요.")
-        String phone
-) {
-
-}
+        String password
+) { }

--- a/src/main/java/com/dedication/force/member/domain/dto/LoginMemberResponse.java
+++ b/src/main/java/com/dedication/force/member/domain/dto/LoginMemberResponse.java
@@ -1,4 +1,4 @@
-package com.dedication.force.article.domain.dto;
+package com.dedication.force.member.domain.dto;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/dedication/force/member/domain/dto/LogoutRequest.java
+++ b/src/main/java/com/dedication/force/member/domain/dto/LogoutRequest.java
@@ -1,3 +1,3 @@
-package com.dedication.force.article.domain.dto;
+package com.dedication.force.member.domain.dto;
 
 public record LogoutRequest(String refreshToken) { }

--- a/src/main/java/com/dedication/force/member/domain/dto/MemberDto.java
+++ b/src/main/java/com/dedication/force/member/domain/dto/MemberDto.java
@@ -1,6 +1,6 @@
-package com.dedication.force.article.domain.dto;
+package com.dedication.force.member.domain.dto;
 
-import com.dedication.force.article.domain.entity.Member;
+import com.dedication.force.member.domain.entity.Member;
 
 import java.time.ZonedDateTime;
 

--- a/src/main/java/com/dedication/force/member/domain/entity/Member.java
+++ b/src/main/java/com/dedication/force/member/domain/entity/Member.java
@@ -1,7 +1,7 @@
-package com.dedication.force.article.domain.entity;
+package com.dedication.force.member.domain.entity;
 
-import com.dedication.force.member.domain.entity.Article;
-import com.dedication.force.member.domain.entity.Comment;
+import com.dedication.force.article.domain.entity.Article;
+import com.dedication.force.comment.domain.entity.Comment;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/dedication/force/member/domain/entity/MemberRole.java
+++ b/src/main/java/com/dedication/force/member/domain/entity/MemberRole.java
@@ -1,4 +1,4 @@
-package com.dedication.force.article.domain.entity;
+package com.dedication.force.member.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/src/main/java/com/dedication/force/member/domain/entity/Role.java
+++ b/src/main/java/com/dedication/force/member/domain/entity/Role.java
@@ -1,4 +1,4 @@
-package com.dedication.force.article.domain.entity;
+package com.dedication.force.member.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/com/dedication/force/member/domain/entity/RoleType.java
+++ b/src/main/java/com/dedication/force/member/domain/entity/RoleType.java
@@ -1,4 +1,4 @@
-package com.dedication.force.article.domain.entity;
+package com.dedication.force.member.domain.entity;
 
 public enum RoleType {
     USER,

--- a/src/main/java/com/dedication/force/member/repository/MemberRepository.java
+++ b/src/main/java/com/dedication/force/member/repository/MemberRepository.java
@@ -1,6 +1,6 @@
 package com.dedication.force.member.repository;
 
-import com.dedication.force.article.domain.entity.Member;
+import com.dedication.force.member.domain.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/dedication/force/member/repository/MemberRoleRepository.java
+++ b/src/main/java/com/dedication/force/member/repository/MemberRoleRepository.java
@@ -1,6 +1,6 @@
 package com.dedication.force.member.repository;
 
-import com.dedication.force.article.domain.entity.MemberRole;
+import com.dedication.force.member.domain.entity.MemberRole;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberRoleRepository extends JpaRepository<MemberRole, Long> {

--- a/src/main/java/com/dedication/force/member/repository/RoleRepository.java
+++ b/src/main/java/com/dedication/force/member/repository/RoleRepository.java
@@ -1,7 +1,7 @@
 package com.dedication.force.member.repository;
 
-import com.dedication.force.article.domain.entity.Role;
-import com.dedication.force.article.domain.entity.RoleType;
+import com.dedication.force.member.domain.entity.Role;
+import com.dedication.force.member.domain.entity.RoleType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/com/dedication/force/member/service/MemberService.java
+++ b/src/main/java/com/dedication/force/member/service/MemberService.java
@@ -1,6 +1,5 @@
 package com.dedication.force.member.service;
 
-import com.dedication.force.article.domain.dto.*;
 import com.dedication.force.article.domain.entity.*;
 import com.dedication.force.common.exception.CustomAPIException;
 import com.dedication.force.common.exception.CustomDataNotFoundException;
@@ -13,6 +12,8 @@ import com.dedication.force.common.jwt.dto.RefreshTokenRequest;
 import com.dedication.force.common.jwt.entity.TokenBlacklist;
 import com.dedication.force.common.jwt.entity.TokenStorage;
 import com.dedication.force.common.security.CustomUserDetailsService;
+import com.dedication.force.member.domain.dto.*;
+import com.dedication.force.member.domain.entity.*;
 import com.dedication.force.member.repository.MemberRepository;
 import com.dedication.force.member.repository.RoleRepository;
 import com.dedication.force.common.jwt.repository.TokenBlacklistRepository;

--- a/src/test/java/com/dedication/force/common/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/dedication/force/common/jwt/JwtTokenProviderTest.java
@@ -1,6 +1,6 @@
 package com.dedication.force.common.jwt;
 
-import com.dedication.force.article.domain.entity.RoleType;
+import com.dedication.force.member.domain.entity.RoleType;
 import com.dedication.force.common.jwt.dto.JwtTokenRequest;
 import io.jsonwebtoken.Claims;
 import org.assertj.core.api.Assertions;

--- a/src/test/java/com/dedication/force/controller/AuthControllerTest.java
+++ b/src/test/java/com/dedication/force/controller/AuthControllerTest.java
@@ -1,11 +1,11 @@
 package com.dedication.force.controller;
 
-import com.dedication.force.article.domain.dto.AddMemberRequest;
-import com.dedication.force.article.domain.dto.LoginMemberRequest;
-import com.dedication.force.article.domain.dto.LoginMemberResponse;
+import com.dedication.force.member.domain.dto.AddMemberRequest;
+import com.dedication.force.member.domain.dto.LoginMemberRequest;
+import com.dedication.force.member.domain.dto.LoginMemberResponse;
 import com.dedication.force.common.jwt.dto.RefreshTokenRequest;
-import com.dedication.force.article.domain.entity.Role;
-import com.dedication.force.article.domain.entity.RoleType;
+import com.dedication.force.member.domain.entity.Role;
+import com.dedication.force.member.domain.entity.RoleType;
 import com.dedication.force.member.repository.MemberRepository;
 import com.dedication.force.member.repository.RoleRepository;
 import com.dedication.force.member.service.MemberService;

--- a/src/test/java/com/dedication/force/service/TokenStorageServiceTest.java
+++ b/src/test/java/com/dedication/force/service/TokenStorageServiceTest.java
@@ -4,7 +4,7 @@ import com.dedication.force.common.jwt.JwtTokenProvider;
 import com.dedication.force.common.jwt.dto.JwtTokenRequest;
 import com.dedication.force.common.jwt.entity.TokenType;
 import com.dedication.force.common.jwt.dto.TokenStorageDto;
-import com.dedication.force.article.domain.entity.RoleType;
+import com.dedication.force.member.domain.entity.RoleType;
 import com.dedication.force.common.jwt.entity.TokenStorage;
 import com.dedication.force.common.jwt.repository.TokenStorageRepository;
 import com.dedication.force.common.jwt.service.TokenStorageService;


### PR DESCRIPTION
이제 게시글과 댓글 도메인을 분리하자. 그리고 잘못 분리된 파일을 다시 제대로 도메인에 따라서 정상적으로 변경하자. 그리고 댓글과 게시글을 분리한다.

 This closes #31 